### PR TITLE
refactor: improve Prisma schema mappings and appointment scheduling model

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "dotenv -e .env.development -- next dev",
     "db:generate": "dotenv -e .env.development -- prisma generate",
     "db:migrate": "dotenv -e .env.development -- prisma migrate dev",
+    "db:deploy": "prisma migrate deploy",
     "db:push": "dotenv -e .env.development -- prisma db push",
     "db:studio": "dotenv -e .env.development -- prisma studio",
     "build": "prisma generate && prisma migrate deploy && next build",

--- a/prisma/migrations/20260509194304_improve_appointment_datetime_range/migration.sql
+++ b/prisma/migrations/20260509194304_improve_appointment_datetime_range/migration.sql
@@ -1,0 +1,236 @@
+/*
+  Warnings:
+
+  - The primary key for the `appointment_services` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `appointmentId` on the `appointment_services` table. All the data in the column will be lost.
+  - You are about to drop the column `serviceDuration` on the `appointment_services` table. All the data in the column will be lost.
+  - You are about to drop the column `serviceId` on the `appointment_services` table. All the data in the column will be lost.
+  - You are about to drop the column `servicePrice` on the `appointment_services` table. All the data in the column will be lost.
+  - The primary key for the `appointments` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `appointmentDatetime` on the `appointments` table. All the data in the column will be lost.
+  - You are about to drop the column `appointmentId` on the `appointments` table. All the data in the column will be lost.
+  - You are about to drop the column `barberId` on the `appointments` table. All the data in the column will be lost.
+  - You are about to drop the column `clientId` on the `appointments` table. All the data in the column will be lost.
+  - You are about to drop the column `createdAt` on the `appointments` table. All the data in the column will be lost.
+  - You are about to drop the column `totalDuration` on the `appointments` table. All the data in the column will be lost.
+  - You are about to drop the column `updatedAt` on the `appointments` table. All the data in the column will be lost.
+  - The primary key for the `barbers` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `barberId` on the `barbers` table. All the data in the column will be lost.
+  - You are about to drop the column `barberName` on the `barbers` table. All the data in the column will be lost.
+  - You are about to drop the column `createdAt` on the `barbers` table. All the data in the column will be lost.
+  - You are about to drop the column `isActive` on the `barbers` table. All the data in the column will be lost.
+  - You are about to drop the column `phoneNumber` on the `barbers` table. All the data in the column will be lost.
+  - You are about to drop the column `updatedAt` on the `barbers` table. All the data in the column will be lost.
+  - The primary key for the `clients` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `clientId` on the `clients` table. All the data in the column will be lost.
+  - You are about to drop the column `clientName` on the `clients` table. All the data in the column will be lost.
+  - You are about to drop the column `clientPhone` on the `clients` table. All the data in the column will be lost.
+  - You are about to drop the column `createdAt` on the `clients` table. All the data in the column will be lost.
+  - You are about to drop the column `isActive` on the `clients` table. All the data in the column will be lost.
+  - You are about to drop the column `updatedAt` on the `clients` table. All the data in the column will be lost.
+  - The primary key for the `services` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `createdAt` on the `services` table. All the data in the column will be lost.
+  - You are about to drop the column `isActive` on the `services` table. All the data in the column will be lost.
+  - You are about to drop the column `serviceDescription` on the `services` table. All the data in the column will be lost.
+  - You are about to drop the column `serviceId` on the `services` table. All the data in the column will be lost.
+  - You are about to drop the column `serviceName` on the `services` table. All the data in the column will be lost.
+  - You are about to drop the column `updatedAt` on the `services` table. All the data in the column will be lost.
+  - The primary key for the `users` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `accessLevel` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `createdAt` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `isActive` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `linkedBarberId` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `updatedAt` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `userId` on the `users` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[barber_id,appointment_datetime]` on the table `appointments` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[linked_barber_id]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `appointment_id` to the `appointment_services` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `service_duration` to the `appointment_services` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `service_id` to the `appointment_services` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `service_price` to the `appointment_services` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `appointment_datetime` to the `appointments` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `appointment_end_datetime` to the `appointments` table without a default value. This is not possible if the table is not empty.
+  - The required column `appointment_id` was added to the `appointments` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+  - Added the required column `barber_id` to the `appointments` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `client_id` to the `appointments` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updated_at` to the `appointments` table without a default value. This is not possible if the table is not empty.
+  - The required column `barber_id` was added to the `barbers` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+  - Added the required column `barber_name` to the `barbers` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updated_at` to the `barbers` table without a default value. This is not possible if the table is not empty.
+  - The required column `client_id` was added to the `clients` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+  - Added the required column `client_name` to the `clients` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updated_at` to the `clients` table without a default value. This is not possible if the table is not empty.
+  - The required column `service_id` was added to the `services` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+  - Added the required column `service_name` to the `services` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updated_at` to the `services` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updated_at` to the `users` table without a default value. This is not possible if the table is not empty.
+  - The required column `user_id` was added to the `users` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "appointment_services" DROP CONSTRAINT "appointment_services_appointmentId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "appointment_services" DROP CONSTRAINT "appointment_services_serviceId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "appointments" DROP CONSTRAINT "appointments_barberId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "appointments" DROP CONSTRAINT "appointments_clientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "users" DROP CONSTRAINT "users_linkedBarberId_fkey";
+
+-- DropIndex
+DROP INDEX "idxAppointmentServicesService";
+
+-- DropIndex
+DROP INDEX "appointments_barberId_appointmentDatetime_key";
+
+-- DropIndex
+DROP INDEX "idxAppointmentsBarber";
+
+-- DropIndex
+DROP INDEX "idxAppointmentsClient";
+
+-- DropIndex
+DROP INDEX "idxAppointmentsDatetime";
+
+-- DropIndex
+DROP INDEX "users_linkedBarberId_key";
+
+-- AlterTable
+ALTER TABLE "appointment_services" DROP CONSTRAINT "appointment_services_pkey",
+DROP COLUMN "appointmentId",
+DROP COLUMN "serviceDuration",
+DROP COLUMN "serviceId",
+DROP COLUMN "servicePrice",
+ADD COLUMN     "appointment_id" UUID NOT NULL,
+ADD COLUMN     "service_duration" INTEGER NOT NULL,
+ADD COLUMN     "service_id" UUID NOT NULL,
+ADD COLUMN     "service_price" DECIMAL(10,2) NOT NULL,
+ADD CONSTRAINT "appointment_services_pkey" PRIMARY KEY ("appointment_id", "service_id");
+
+-- AlterTable
+ALTER TABLE "appointments" DROP CONSTRAINT "appointments_pkey",
+DROP COLUMN "appointmentDatetime",
+DROP COLUMN "appointmentId",
+DROP COLUMN "barberId",
+DROP COLUMN "clientId",
+DROP COLUMN "createdAt",
+DROP COLUMN "totalDuration",
+DROP COLUMN "updatedAt",
+ADD COLUMN     "appointment_datetime" TIMESTAMPTZ(3) NOT NULL,
+ADD COLUMN     "appointment_end_datetime" TIMESTAMPTZ(3) NOT NULL,
+ADD COLUMN     "appointment_id" UUID NOT NULL,
+ADD COLUMN     "barber_id" UUID NOT NULL,
+ADD COLUMN     "client_id" UUID NOT NULL,
+ADD COLUMN     "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "total_duration" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "updated_at" TIMESTAMPTZ(3) NOT NULL,
+ADD CONSTRAINT "appointments_pkey" PRIMARY KEY ("appointment_id");
+
+-- AlterTable
+ALTER TABLE "barbers" DROP CONSTRAINT "barbers_pkey",
+DROP COLUMN "barberId",
+DROP COLUMN "barberName",
+DROP COLUMN "createdAt",
+DROP COLUMN "isActive",
+DROP COLUMN "phoneNumber",
+DROP COLUMN "updatedAt",
+ADD COLUMN     "barber_id" UUID NOT NULL,
+ADD COLUMN     "barber_name" VARCHAR(100) NOT NULL,
+ADD COLUMN     "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "is_active" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "lunch_end" VARCHAR(5),
+ADD COLUMN     "lunch_start" VARCHAR(5),
+ADD COLUMN     "phone_number" VARCHAR(30),
+ADD COLUMN     "updated_at" TIMESTAMPTZ(3) NOT NULL,
+ADD COLUMN     "work_end" VARCHAR(5),
+ADD COLUMN     "work_start" VARCHAR(5),
+ADD CONSTRAINT "barbers_pkey" PRIMARY KEY ("barber_id");
+
+-- AlterTable
+ALTER TABLE "clients" DROP CONSTRAINT "clients_pkey",
+DROP COLUMN "clientId",
+DROP COLUMN "clientName",
+DROP COLUMN "clientPhone",
+DROP COLUMN "createdAt",
+DROP COLUMN "isActive",
+DROP COLUMN "updatedAt",
+ADD COLUMN     "client_id" UUID NOT NULL,
+ADD COLUMN     "client_name" VARCHAR(100) NOT NULL,
+ADD COLUMN     "client_phone" VARCHAR(30),
+ADD COLUMN     "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "is_active" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "updated_at" TIMESTAMPTZ(3) NOT NULL,
+ADD CONSTRAINT "clients_pkey" PRIMARY KEY ("client_id");
+
+-- AlterTable
+ALTER TABLE "services" DROP CONSTRAINT "services_pkey",
+DROP COLUMN "createdAt",
+DROP COLUMN "isActive",
+DROP COLUMN "serviceDescription",
+DROP COLUMN "serviceId",
+DROP COLUMN "serviceName",
+DROP COLUMN "updatedAt",
+ADD COLUMN     "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "is_active" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "service_description" VARCHAR(150),
+ADD COLUMN     "service_id" UUID NOT NULL,
+ADD COLUMN     "service_name" VARCHAR(80) NOT NULL,
+ADD COLUMN     "updated_at" TIMESTAMPTZ(3) NOT NULL,
+ADD CONSTRAINT "services_pkey" PRIMARY KEY ("service_id");
+
+-- AlterTable
+ALTER TABLE "users" DROP CONSTRAINT "users_pkey",
+DROP COLUMN "accessLevel",
+DROP COLUMN "createdAt",
+DROP COLUMN "isActive",
+DROP COLUMN "linkedBarberId",
+DROP COLUMN "updatedAt",
+DROP COLUMN "userId",
+ADD COLUMN     "access_level" "AccessLevel" NOT NULL DEFAULT 'barber',
+ADD COLUMN     "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "is_active" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "linked_barber_id" UUID,
+ADD COLUMN     "updated_at" TIMESTAMPTZ(3) NOT NULL,
+ADD COLUMN     "user_id" UUID NOT NULL,
+ADD CONSTRAINT "users_pkey" PRIMARY KEY ("user_id");
+
+-- CreateIndex
+CREATE INDEX "idxAppointmentServicesService" ON "appointment_services"("service_id");
+
+-- CreateIndex
+CREATE INDEX "idxAppointmentsClient" ON "appointments"("client_id");
+
+-- CreateIndex
+CREATE INDEX "idxAppointmentsDatetime" ON "appointments"("appointment_datetime");
+
+-- CreateIndex
+CREATE INDEX "idxAppointmentsBarberStatusDatetime" ON "appointments"("barber_id", "status", "appointment_datetime");
+
+-- CreateIndex
+CREATE INDEX "idxAppointmentsBarberStatusRange" ON "appointments"("barber_id", "status", "appointment_datetime", "appointment_end_datetime");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "appointments_barber_id_appointment_datetime_key" ON "appointments"("barber_id", "appointment_datetime");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_linked_barber_id_key" ON "users"("linked_barber_id");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_linked_barber_id_fkey" FOREIGN KEY ("linked_barber_id") REFERENCES "barbers"("barber_id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_client_id_fkey" FOREIGN KEY ("client_id") REFERENCES "clients"("client_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointments" ADD CONSTRAINT "appointments_barber_id_fkey" FOREIGN KEY ("barber_id") REFERENCES "barbers"("barber_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment_services" ADD CONSTRAINT "appointment_services_appointment_id_fkey" FOREIGN KEY ("appointment_id") REFERENCES "appointments"("appointment_id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment_services" ADD CONSTRAINT "appointment_services_service_id_fkey" FOREIGN KEY ("service_id") REFERENCES "services"("service_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,12 +22,12 @@ enum AppointmentStatus {
 }
 
 model Client {
-  clientId    String   @id @default(uuid()) @db.Uuid
-  clientName  String   @db.VarChar(100)
-  clientPhone String?  @db.VarChar(30)
-  isActive    Boolean  @default(true)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  clientId    String   @id @default(uuid()) @map("client_id") @db.Uuid
+  clientName  String   @map("client_name") @db.VarChar(100)
+  clientPhone String?  @map("client_phone") @db.VarChar(30)
+  isActive    Boolean  @default(true) @map("is_active")
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   appointments Appointment[]
 
@@ -35,12 +35,18 @@ model Client {
 }
 
 model Barber {
-  barberId    String   @id @default(uuid()) @db.Uuid
-  barberName  String   @db.VarChar(100)
-  phoneNumber String?  @db.VarChar(30)
-  isActive    Boolean  @default(true)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  barberId    String  @id @default(uuid()) @map("barber_id") @db.Uuid
+  barberName  String  @map("barber_name") @db.VarChar(100)
+  phoneNumber String? @map("phone_number") @db.VarChar(30)
+
+  workStart  String? @map("work_start") @db.VarChar(5)
+  workEnd    String? @map("work_end") @db.VarChar(5)
+  lunchStart String? @map("lunch_start") @db.VarChar(5)
+  lunchEnd   String? @map("lunch_end") @db.VarChar(5)
+
+  isActive  Boolean  @default(true) @map("is_active")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   appointments Appointment[]
   user         User?
@@ -49,14 +55,14 @@ model Barber {
 }
 
 model Service {
-  serviceId          String   @id @default(uuid()) @db.Uuid
-  serviceName        String   @db.VarChar(80)
-  serviceDescription String?  @db.VarChar(150)
+  serviceId          String   @id @default(uuid()) @map("service_id") @db.Uuid
+  serviceName        String   @map("service_name") @db.VarChar(80)
+  serviceDescription String?  @map("service_description") @db.VarChar(150)
   duration           Int
   price              Decimal  @db.Decimal(10, 2)
-  isActive           Boolean  @default(true)
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  isActive           Boolean  @default(true) @map("is_active")
+  createdAt          DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt          DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   appointmentServices AppointmentService[]
 
@@ -64,14 +70,14 @@ model Service {
 }
 
 model User {
-  userId         String      @id @default(uuid()) @db.Uuid
+  userId         String      @id @default(uuid()) @map("user_id") @db.Uuid
   username       String      @unique @db.VarChar(50)
   passwordHash   String      @map("password_hash") @db.VarChar(255)
-  accessLevel    AccessLevel @default(barber)
-  linkedBarberId String?     @unique @db.Uuid
-  isActive       Boolean     @default(true)
-  createdAt      DateTime    @default(now())
-  updatedAt      DateTime    @updatedAt
+  accessLevel    AccessLevel @default(barber) @map("access_level")
+  linkedBarberId String?     @unique @map("linked_barber_id") @db.Uuid
+  isActive       Boolean     @default(true) @map("is_active")
+  createdAt      DateTime    @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt      DateTime    @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   barber Barber? @relation(fields: [linkedBarberId], references: [barberId], onDelete: SetNull)
 
@@ -79,16 +85,17 @@ model User {
 }
 
 model Appointment {
-  appointmentId       String            @id @default(uuid()) @db.Uuid
-  appointmentDatetime DateTime
-  totalDuration       Int               @default(0)
-  status              AppointmentStatus @default(AGENDADO)
+  appointmentId          String            @id @default(uuid()) @map("appointment_id") @db.Uuid
+  appointmentDatetime    DateTime          @map("appointment_datetime") @db.Timestamptz(3)
+  appointmentEndDatetime DateTime          @map("appointment_end_datetime") @db.Timestamptz(3)
+  totalDuration          Int               @default(0) @map("total_duration")
+  status                 AppointmentStatus @default(AGENDADO)
 
-  clientId String @db.Uuid
-  barberId String @db.Uuid
+  clientId String @map("client_id") @db.Uuid
+  barberId String @map("barber_id") @db.Uuid
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
 
   client Client @relation(fields: [clientId], references: [clientId], onDelete: Restrict)
   barber Barber @relation(fields: [barberId], references: [barberId], onDelete: Restrict)
@@ -96,18 +103,19 @@ model Appointment {
   appointmentServices AppointmentService[]
 
   @@unique([barberId, appointmentDatetime], name: "uqBarberDatetime")
-  @@index([barberId], name: "idxAppointmentsBarber")
   @@index([clientId], name: "idxAppointmentsClient")
   @@index([appointmentDatetime], name: "idxAppointmentsDatetime")
+  @@index([barberId, status, appointmentDatetime], name: "idxAppointmentsBarberStatusDatetime")
+  @@index([barberId, status, appointmentDatetime, appointmentEndDatetime], name: "idxAppointmentsBarberStatusRange")
   @@map("appointments")
 }
 
 model AppointmentService {
-  appointmentId String @db.Uuid
-  serviceId     String @db.Uuid
+  appointmentId String @map("appointment_id") @db.Uuid
+  serviceId     String @map("service_id") @db.Uuid
 
-  servicePrice    Decimal @db.Decimal(10, 2)
-  serviceDuration Int
+  servicePrice    Decimal @map("service_price") @db.Decimal(10, 2)
+  serviceDuration Int     @map("service_duration")
 
   appointment Appointment @relation(fields: [appointmentId], references: [appointmentId], onDelete: Cascade)
   service     Service     @relation(fields: [serviceId], references: [serviceId], onDelete: Restrict)


### PR DESCRIPTION
## Summary

This PR refactors the Prisma schema to improve PostgreSQL compatibility, database naming consistency, and appointment scheduling validation support.

The main goal was to make the schema cleaner and more production-ready for the Barbershop Appointment System, while keeping Prisma Client usage ergonomic in the application code.

## Changes

- Added explicit `@map` mappings to keep Prisma fields in `camelCase` while using `snake_case` columns in PostgreSQL.
- Added `@@map`-compatible field naming across the main models:
  - `Client`
  - `Barber`
  - `Service`
  - `User`
  - `Appointment`
  - `AppointmentService`
- Changed `DateTime` fields to use `@db.Timestamptz(3)` for better PostgreSQL timestamp handling.
- Added `appointmentEndDatetime` to `Appointment` to support appointment duration/range validation.
- Added scheduling fields to `Barber`:
  - `workStart`
  - `workEnd`
  - `lunchStart`
  - `lunchEnd`
- Added appointment indexes for common dashboard and availability queries:
  - appointments by client
  - appointments by datetime
  - appointments by barber/status/datetime
  - appointments by barber/status/datetime range
- Removed the redundant standalone barber appointment index in favor of more useful composite indexes.
- Kept historical appointment service data through `servicePrice` and `serviceDuration`.

## Why

The previous schema worked, but most database columns were being created with `camelCase` names. This PR keeps the application code clean with Prisma-style `camelCase`, while making the actual PostgreSQL schema follow the more conventional `snake_case` naming style.

The appointment model was also improved to better support scheduling rules. Previously, the schema could prevent two appointments from starting at the exact same time for the same barber, but it did not provide a clean way to validate overlapping appointment ranges. Adding `appointmentEndDatetime` makes overlap validation simpler and more reliable in the application layer.

The new barber scheduling fields will also help validate whether an appointment is inside working hours and outside lunch breaks.

## Notes

This migration includes column renames from the application perspective, but Prisma generated them as drop/add operations because the underlying database column names changed from `camelCase` to `snake_case`.

This is acceptable for the current project state because both the local PostgreSQL database and the Neon production database do not contain relevant data yet.

For a production database with real data, this migration would need to be rewritten manually using `ALTER TABLE ... RENAME COLUMN` statements to preserve existing records.