### PR TITLE
test(orchestrator): add reusable user creation helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@faker-js/faker": "9.7.0",
         "@prisma/adapter-pg": "7.8.0",
         "@prisma/client": "7.8.0",
         "@tailwindcss/container-queries": "0.1.1",
@@ -1219,6 +1220,22 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.7.0.tgz",
+      "integrity": "sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@hapi/address": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@faker-js/faker": "9.7.0",
     "@prisma/adapter-pg": "7.8.0",
     "@prisma/client": "7.8.0",
     "@tailwindcss/container-queries": "0.1.1",

--- a/src/infra/prisma.js
+++ b/src/infra/prisma.js
@@ -45,10 +45,6 @@ export const prisma =
         connectionString: process.env.DATABASE_URL,
       }),
     ),
-    log:
-      process.env.NODE_ENV === "development"
-        ? ["query", "warn", "error"]
-        : ["error"],
   });
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/tests/integration/api/v1/users/[username]/get-username.test.js
+++ b/src/tests/integration/api/v1/users/[username]/get-username.test.js
@@ -1,87 +1,60 @@
 import webserver from "@/infra/webserver.mjs";
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
 
 describe("GET /api/v1/users/[username]", () => {
   describe("Anonymous user", () => {
     test("With exact case match", async () => {
-      const response1 = await fetch(`${webserver.origin}/api/v1/users`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "SameCase",
-          email: "samecase@test.com",
-          password: "SehrSicheresPasswort",
-          accessLevel: "barber",
-        }),
-      });
-
-      expect(response1.status).toBe(201);
-
-      const response1Body = await response1.json();
-
-      const response2 = await fetch(
-        `${webserver.origin}/api/v1/users/SameCase`,
-      );
-
-      expect(response2.status).toBe(200);
-
-      const response2Body = await response2.json();
-
-      expect(response2Body).toEqual({
-        userId: response1Body.userId,
+      const createdUser = await orchestrator.createUser({
         username: "SameCase",
-        email: "samecase@test.com",
-        accessLevel: "barber",
-        linkedBarberId: null,
-        isActive: true,
-        createdAt: response1Body.createdAt,
-        updatedAt: response1Body.updatedAt,
       });
 
-      expect(Date.parse(response2Body.createdAt)).not.toBeNaN();
-      expect(Date.parse(response2Body.updatedAt)).not.toBeNaN();
+      const response = await fetch(`${webserver.origin}/api/v1/users/SameCase`);
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        userId: createdUser.userId,
+        username: "SameCase",
+        email: createdUser.email,
+        accessLevel: createdUser.accessLevel,
+        linkedBarberId: createdUser.linkedBarberId,
+        isActive: createdUser.isActive,
+        createdAt: createdUser.createdAt.toISOString(),
+        updatedAt: createdUser.updatedAt.toISOString(),
+      });
+
+      expect(Date.parse(responseBody.createdAt)).not.toBeNaN();
+      expect(Date.parse(responseBody.updatedAt)).not.toBeNaN();
     });
 
     test("With case mismatch", async () => {
-      const response1 = await fetch(`${webserver.origin}/api/v1/users`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "DifferentCase",
-          email: "differentcase@test.com",
-          password: "SehrSicheresPasswort",
-          accessLevel: "barber",
-        }),
+      const createdUser = await orchestrator.createUser({
+        username: "DifferentCase",
       });
 
-      expect(response1.status).toBe(201);
-
-      const response1Body = await response1.json();
-
-      const response2 = await fetch(
+      const response = await fetch(
         `${webserver.origin}/api/v1/users/differentcase`,
       );
 
-      expect(response2.status).toBe(200);
+      expect(response.status).toBe(200);
 
-      const response2Body = await response2.json();
+      const responseBody = await response.json();
 
-      expect(response2Body).toEqual({
-        userId: response1Body.userId,
+      expect(responseBody).toEqual({
+        userId: createdUser.userId,
         username: "DifferentCase",
-        email: "differentcase@test.com",
-        accessLevel: "barber",
-        linkedBarberId: null,
-        isActive: true,
-        createdAt: response1Body.createdAt,
-        updatedAt: response1Body.updatedAt,
+        email: createdUser.email,
+        accessLevel: createdUser.accessLevel,
+        linkedBarberId: createdUser.linkedBarberId,
+        isActive: createdUser.isActive,
+        createdAt: createdUser.createdAt.toISOString(),
+        updatedAt: createdUser.updatedAt.toISOString(),
       });
 
-      expect(Date.parse(response2Body.createdAt)).not.toBeNaN();
-      expect(Date.parse(response2Body.updatedAt)).not.toBeNaN();
+      expect(Date.parse(responseBody.createdAt)).not.toBeNaN();
+      expect(Date.parse(responseBody.updatedAt)).not.toBeNaN();
     });
 
     test("With nonexistent username", async () => {

--- a/src/tests/integration/api/v1/users/[username]/patch-username.test.js
+++ b/src/tests/integration/api/v1/users/[username]/patch-username.test.js
@@ -1,8 +1,9 @@
-import password from "@/infra/password";
+import password from "@/infra/password.js";
 import webserver from "@/infra/webserver.mjs";
 import { prisma as db } from "@/infra/prisma.js";
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
 
-describe("GET /api/v1/users/[username]", () => {
+describe("PATCH /api/v1/users/[username]", () => {
   describe("Anonymous user", () => {
     test("With nonexistent `username`", async () => {
       const response = await fetch(
@@ -25,43 +26,27 @@ describe("GET /api/v1/users/[username]", () => {
     });
 
     test("With duplicated 'username'", async () => {
-      const user1response = await fetch(`${webserver.origin}/api/v1/users`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "user1",
-          email: "user1@test.com",
-          password: "LOCAL_PASSWORD",
-          accessLevel: "barber",
-        }),
+      const createdUser1 = await orchestrator.createUser({
+        username: "user1",
       });
-      expect(user1response.status).toBe(201);
 
-      const user2response = await fetch(`${webserver.origin}/api/v1/users`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "user2",
-          email: "user2@test.com",
-          password: "LOCAL_PASSWORD",
-          accessLevel: "barber",
-        }),
+      const createdUser2 = await orchestrator.createUser({
+        username: "user2",
       });
-      expect(user2response.status).toBe(201);
 
-      const response = await fetch(`${webserver.origin}/api/v1/users/user2`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await fetch(
+        `${webserver.origin}/api/v1/users/${createdUser2.username}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            username: createdUser1.username,
+          }),
         },
-        body: JSON.stringify({
-          username: "user1",
-        }),
-      });
+      );
+
       expect(response.status).toBe(400);
 
       const responseBody = await response.json();
@@ -75,43 +60,27 @@ describe("GET /api/v1/users/[username]", () => {
     });
 
     test("With duplicated 'email'", async () => {
-      const email1response = await fetch(`${webserver.origin}/api/v1/users`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "email1",
-          email: "email1@test.com",
-          password: "LOCAL_PASSWORD",
-          accessLevel: "barber",
-        }),
+      const createdUser1 = await orchestrator.createUser({
+        email: "email1@test.com",
       });
-      expect(email1response.status).toBe(201);
 
-      const email2response = await fetch(`${webserver.origin}/api/v1/users`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "email2",
-          email: "email2@test.com",
-          password: "LOCAL_PASSWORD",
-          accessLevel: "barber",
-        }),
+      const createdUser2 = await orchestrator.createUser({
+        email: "email2@test.com",
       });
-      expect(email2response.status).toBe(201);
 
-      const response = await fetch(`${webserver.origin}/api/v1/users/email2`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await fetch(
+        `${webserver.origin}/api/v1/users/${createdUser2.username}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: createdUser1.email,
+          }),
         },
-        body: JSON.stringify({
-          email: "email1@test.com",
-        }),
-      });
+      );
+
       expect(response.status).toBe(400);
 
       const responseBody = await response.json();
@@ -125,22 +94,15 @@ describe("GET /api/v1/users/[username]", () => {
     });
 
     test("With unique 'username'", async () => {
-      const user1response = await fetch(`${webserver.origin}/api/v1/users`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "uniqueUser1",
-          email: "uniqueUser1@test.com",
-          password: "LOCAL_PASSWORD",
-          accessLevel: "barber",
-        }),
+      const createdUser = await orchestrator.createUser({
+        username: "uniqueUser1",
+        email: "uniqueUser1@test.com",
+        password: "LOCAL_PASSWORD",
+        accessLevel: "barber",
       });
-      expect(user1response.status).toBe(201);
 
       const response = await fetch(
-        `${webserver.origin}/api/v1/users/uniqueUser1`,
+        `${webserver.origin}/api/v1/users/${createdUser.username}`,
         {
           method: "PATCH",
           headers: {
@@ -151,18 +113,19 @@ describe("GET /api/v1/users/[username]", () => {
           }),
         },
       );
+
       expect(response.status).toBe(200);
 
       const responseBody = await response.json();
 
       expect(responseBody).toEqual({
-        userId: responseBody.userId,
+        userId: createdUser.userId,
         username: "uniqueUser2",
         email: "uniqueuser1@test.com",
         accessLevel: "barber",
         linkedBarberId: null,
         isActive: true,
-        createdAt: responseBody.createdAt,
+        createdAt: createdUser.createdAt.toISOString(),
         updatedAt: responseBody.updatedAt,
       });
 
@@ -173,22 +136,15 @@ describe("GET /api/v1/users/[username]", () => {
     });
 
     test("With unique 'email'", async () => {
-      const user1response = await fetch(`${webserver.origin}/api/v1/users`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "uniqueEmail1",
-          email: "uniqueemail1@test.com",
-          password: "LOCAL_PASSWORD",
-          accessLevel: "barber",
-        }),
+      const createdUser = await orchestrator.createUser({
+        username: "uniqueEmail1",
+        email: "uniqueemail1@test.com",
+        password: "LOCAL_PASSWORD",
+        accessLevel: "barber",
       });
-      expect(user1response.status).toBe(201);
 
       const response = await fetch(
-        `${webserver.origin}/api/v1/users/uniqueEmail1`,
+        `${webserver.origin}/api/v1/users/${createdUser.username}`,
         {
           method: "PATCH",
           headers: {
@@ -199,18 +155,19 @@ describe("GET /api/v1/users/[username]", () => {
           }),
         },
       );
+
       expect(response.status).toBe(200);
 
       const responseBody = await response.json();
 
       expect(responseBody).toEqual({
-        userId: responseBody.userId,
+        userId: createdUser.userId,
         username: "uniqueEmail1",
         email: "uniqueemail2@test.com",
         accessLevel: "barber",
         linkedBarberId: null,
         isActive: true,
-        createdAt: responseBody.createdAt,
+        createdAt: createdUser.createdAt.toISOString(),
         updatedAt: responseBody.updatedAt,
       });
 
@@ -221,22 +178,15 @@ describe("GET /api/v1/users/[username]", () => {
     });
 
     test("With new 'password'", async () => {
-      const userResponse = await fetch(`${webserver.origin}/api/v1/users`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "NewPassword1",
-          email: "newpassword1@test.com",
-          password: "NewPassword1",
-          accessLevel: "barber",
-        }),
+      const createdUser = await orchestrator.createUser({
+        username: "NewPassword1",
+        email: "newpassword1@test.com",
+        password: "NewPassword1",
+        accessLevel: "barber",
       });
-      expect(userResponse.status).toBe(201);
 
       const response = await fetch(
-        `${webserver.origin}/api/v1/users/NewPassword1`,
+        `${webserver.origin}/api/v1/users/${createdUser.username}`,
         {
           method: "PATCH",
           headers: {
@@ -247,18 +197,19 @@ describe("GET /api/v1/users/[username]", () => {
           }),
         },
       );
+
       expect(response.status).toBe(200);
 
       const responseBody = await response.json();
 
       expect(responseBody).toEqual({
-        userId: responseBody.userId,
+        userId: createdUser.userId,
         username: "NewPassword1",
         email: "newpassword1@test.com",
         accessLevel: "barber",
         linkedBarberId: null,
         isActive: true,
-        createdAt: responseBody.createdAt,
+        createdAt: createdUser.createdAt.toISOString(),
         updatedAt: responseBody.updatedAt,
       });
 

--- a/src/tests/orchestrator/orchestrator.mjs
+++ b/src/tests/orchestrator/orchestrator.mjs
@@ -1,8 +1,11 @@
 import { execFileSync } from "node:child_process";
 
 import retry from "async-retry";
+import { faker } from "@faker-js/faker";
 
 import webserver from "../../infra/webserver.mjs";
+import { prisma as db } from "../../infra/prisma.js";
+import password from "../../infra/password.js";
 
 // const emailHttpUrl = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
 
@@ -15,6 +18,7 @@ async function waitForAllServices() {
     const messageReady = "Services ready!";
 
     const startedAt = Date.now();
+
     function showElapsedTime() {
       return `${((Date.now() - startedAt) / 1000).toFixed(2)}s`;
     }
@@ -24,6 +28,7 @@ async function waitForAllServices() {
       const spinner = ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"];
       const index =
         Math.floor(Date.now() / intervalToUpdateMs) % spinner.length;
+
       return `${showElapsedTime()} ${spinner[index]}`;
     }
 
@@ -34,29 +39,17 @@ async function waitForAllServices() {
 
     async function fetchStatusPage() {
       process.stdout.write(`\r🟡 ${messageWaiting} ${showSpinner()}`);
+
       const response = await fetch(`${webserver.origin}/api/v1/status`);
+
       if (response.status !== 200) {
         throw new Error("Web server is not ready yet.");
       }
+
       process.stdout.write(`\r⚫ ${messageWaiting} - ${showElapsedTime()}`);
       process.stdout.write(`\n🟢 ${messageReady}\n`);
     }
   }
-
-  // async function waitForEmailServer() {
-  //   return retry(fetchEmailPage, {
-  //     retries: 100,
-  //     maxTimeout: 1000,
-  //   });
-
-  //   async function fetchEmailPage() {
-  //     const response = await fetch(emailHttpUrl);
-
-  //     if (response.status !== 200) {
-  //       throw new Error("Email server is not ready yet.");
-  //     }
-  //   }
-  // }
 }
 
 /**
@@ -75,12 +68,6 @@ async function clearDatabase() {
     stdio: "inherit",
     env: {
       ...process.env,
-
-      /**
-       * Prisma may block destructive commands when they are triggered by
-       * AI-assisted workflows. This variable documents explicit consent for
-       * this destructive test-only reset.
-       */
       PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION:
         "I understand this command resets the test database and destroys all test data.",
     },
@@ -114,9 +101,32 @@ function assertSafeEnvironment() {
   }
 }
 
+async function createUser(userObject = {}) {
+  const username =
+    userObject.username || faker.internet.username().replace(/[_.-]/g, "");
+
+  const email = (userObject.email || faker.internet.email()).toLowerCase();
+
+  const passwordHash = await password.hash(
+    userObject.password || "supersecurepassword123",
+  );
+
+  return await db.user.create({
+    data: {
+      username,
+      email,
+      passwordHash,
+      accessLevel: userObject.accessLevel || "barber",
+      linkedBarberId: userObject.linkedBarberId || null,
+      isActive: userObject.isActive ?? true,
+    },
+  });
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
+  createUser,
 };
 
 export default orchestrator;


### PR DESCRIPTION
## Summary

This PR improves the integration test workflow by adding a reusable `orchestrator.createUser()` helper and using it in the username endpoint tests.

The goal is to keep endpoint tests focused on the behavior they are actually validating, instead of repeatedly creating users through `POST /api/v1/users` inside tests that are not about user creation.

## Changes

- Added `orchestrator.createUser()`
  - Creates test users directly through Prisma
  - Uses Faker to fill missing user fields
  - Hashes passwords before storing them
  - Provides defaults for `accessLevel`, `linkedBarberId`, and `isActive`

- Refactored username endpoint tests
  - Replaced repetitive HTTP user creation setup with `orchestrator.createUser()`
  - Simplified GET `/api/v1/users/[username]` tests
  - Simplified PATCH `/api/v1/users/[username]` tests
  - Fixed the PATCH test suite description from `GET` to `PATCH`

## Why

This reduces repetition in integration tests and improves test clarity, improving dev experience.

Tests for GET/PATCH user endpoints should not depend on the user creation endpoint unless they are explicitly testing the full flow. User creation is now handled as setup data through the orchestrator.