### PR TITLE
feat(auth): add session-based authorization flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,14 @@
         "@tailwindcss/forms": "0.5.11",
         "@tailwindcss/postcss": "4.2.4",
         "bcryptjs": "3.0.3",
+        "cookie": "1.1.1",
         "dotenv": "17.4.2",
         "next": "16.2.4",
         "next-connect": "1.0.0",
         "pg": "8.20.0",
         "react": "19.2.5",
-        "react-dom": "19.2.5"
+        "react-dom": "19.2.5",
+        "uuid": "11.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "20.5.3",
@@ -50,6 +52,7 @@
         "postcss": "8.5.13",
         "prettier": "3.8.3",
         "prisma": "7.8.0",
+        "set-cookie-parser": "3.1.0",
         "tailwindcss": "4.2.4",
         "wait-on": "9.0.5"
       }
@@ -5215,6 +5218,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
@@ -11811,6 +11827,13 @@
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
       "devOptional": true
     },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -12993,6 +13016,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,14 @@
     "@tailwindcss/forms": "0.5.11",
     "@tailwindcss/postcss": "4.2.4",
     "bcryptjs": "3.0.3",
+    "cookie": "1.1.1",
     "dotenv": "17.4.2",
     "next": "16.2.4",
     "next-connect": "1.0.0",
     "pg": "8.20.0",
     "react": "19.2.5",
-    "react-dom": "19.2.5"
+    "react-dom": "19.2.5",
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "20.5.3",
@@ -68,6 +70,7 @@
     "postcss": "8.5.13",
     "prettier": "3.8.3",
     "prisma": "7.8.0",
+    "set-cookie-parser": "3.1.0",
     "tailwindcss": "4.2.4",
     "wait-on": "9.0.5"
   }

--- a/prisma/migrations/20260523230801_add_users_sessions/migration.sql
+++ b/prisma/migrations/20260523230801_add_users_sessions/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "sessions" (
+    "session_id" UUID NOT NULL,
+    "token_hash" VARCHAR(64) NOT NULL,
+    "user_id" UUID NOT NULL,
+    "expires_at" TIMESTAMPTZ(3) NOT NULL,
+    "created_at" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("session_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_token_hash_key" ON "sessions"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "idxSessionsUser" ON "sessions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "idxSessionsExpiresAt" ON "sessions"("expires_at");
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("user_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,9 +81,27 @@ model User {
   createdAt      DateTime    @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt      DateTime    @updatedAt @map("updated_at") @db.Timestamptz(3)
 
-  barber Barber? @relation(fields: [linkedBarberId], references: [barberId], onDelete: SetNull)
+  barber   Barber?   @relation(fields: [linkedBarberId], references: [barberId], onDelete: SetNull)
+  sessions Session[]
 
   @@map("users")
+}
+
+model Session {
+  sessionId String @id @default(uuid()) @map("session_id") @db.Uuid
+
+  tokenHash String @unique @map("token_hash") @db.VarChar(64)
+  userId    String @map("user_id") @db.Uuid
+
+  expiresAt DateTime @map("expires_at") @db.Timestamptz(3)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(3)
+
+  user User @relation(fields: [userId], references: [userId], onDelete: Cascade)
+
+  @@index([userId], name: "idxSessionsUser")
+  @@index([expiresAt], name: "idxSessionsExpiresAt")
+  @@map("sessions")
 }
 
 model Appointment {

--- a/src/infra/authentication.js
+++ b/src/infra/authentication.js
@@ -1,0 +1,70 @@
+import { UnauthorizedError } from "@/infra/errors";
+import password from "@/infra/password.js";
+import { prisma as db } from "@/infra/prisma.js";
+
+// Used to reduce timing differences between:
+// - email not found
+// - email found, but password incorrect
+//
+// These hashes do not represent real user passwords.
+// The non-production hash uses a low cost to keep tests/development fast.
+const FAKE_PASSWORD_HASH_PRODUCTION =
+  "$2b$14$7Ko/sXjK7Z65cOcrK7aUPO9qIWl9rSvswcFXmoACUzOHZIiLv1mJe";
+
+const FAKE_PASSWORD_HASH_NON_PRODUCTION =
+  "$2b$04$7Ko/sXjK7Z65cOcrK7aUPO9qIWl9rSvswcFXmoACUzOHZIiLv1mJe";
+
+async function getAuthenticatedUser({
+  email: providedEmail,
+  password: providedPassword,
+}) {
+  const normalizedEmail = providedEmail.trim().toLowerCase();
+
+  const storedUser = await db.user.findUnique({
+    where: {
+      email: normalizedEmail,
+    },
+    select: {
+      userId: true,
+      username: true,
+      email: true,
+      passwordHash: true,
+      accessLevel: true,
+      linkedBarberId: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  const passwordHashToCompare =
+    storedUser?.passwordHash || getFakePasswordHash();
+
+  const passwordMatches = await password.compare(
+    providedPassword,
+    passwordHashToCompare,
+  );
+
+  if (!storedUser || !passwordMatches) {
+    throw new UnauthorizedError({
+      message: "Invalid email or password.",
+      action: "Check your credentials and try again.",
+    });
+  }
+
+  return storedUser;
+}
+
+function getFakePasswordHash() {
+  if (process.env.NODE_ENV === "production") {
+    return FAKE_PASSWORD_HASH_PRODUCTION;
+  }
+
+  return FAKE_PASSWORD_HASH_NON_PRODUCTION;
+}
+
+const authentication = {
+  getAuthenticatedUser,
+};
+
+export default authentication;

--- a/src/infra/controller.js
+++ b/src/infra/controller.js
@@ -1,18 +1,12 @@
+import * as cookie from "cookie";
+
 import {
   InternalServerError,
   MethodNotAllowedError,
   ValidationError,
   NotFoundError,
+  UnauthorizedError,
 } from "./errors.js";
-
-const controller = {
-  errorHandlers: {
-    onNoMatch: onNoMatchHandler,
-    onError: onErrorHandler,
-  },
-};
-
-export default controller;
 
 function onNoMatchHandler(request, response) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -24,6 +18,11 @@ function onErrorHandler(error, request, response) {
     return response.status(error.statusCode).json(error);
   }
 
+  if (error instanceof UnauthorizedError) {
+    clearSessionCookie(response);
+    return response.status(error.statusCode).json(error);
+  }
+
   const publicErrorObject = new InternalServerError({
     cause: error,
   });
@@ -32,3 +31,25 @@ function onErrorHandler(error, request, response) {
 
   response.status(500).json(publicErrorObject);
 }
+
+function clearSessionCookie(response) {
+  const setCookie = cookie.serialize("session_id", "invalid", {
+    path: "/",
+    maxAge: -1,
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+    sameSite: "lax",
+  });
+
+  response.setHeader("Set-Cookie", setCookie);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+  clearSessionCookie,
+};
+
+export default controller;

--- a/src/infra/session.js
+++ b/src/infra/session.js
@@ -1,0 +1,133 @@
+import crypto from "node:crypto";
+
+import * as cookie from "cookie";
+
+import { prisma as db } from "./prisma.js";
+
+const SESSION_DURATION_IN_MILLISECONDS = 60 * 60 * 24 * 30 * 1000; // 30 days
+const SESSION_DURATION_IN_SECONDS = SESSION_DURATION_IN_MILLISECONDS / 1000;
+const SESSION_COOKIE_NAME = "session_id";
+
+async function create(userId) {
+  const rawSessionToken = generateSessionToken();
+  const sessionTokenHash = hashSessionToken(rawSessionToken);
+  const expiresAt = new Date(Date.now() + SESSION_DURATION_IN_MILLISECONDS);
+
+  const createdSession = await db.session.create({
+    data: {
+      tokenHash: sessionTokenHash,
+      userId,
+      expiresAt,
+    },
+    select: {
+      sessionId: true,
+      userId: true,
+      expiresAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  const sessionCookie = createSessionCookie(rawSessionToken);
+
+  return {
+    session: createdSession,
+    sessionCookie,
+  };
+}
+
+async function findValidSessionbyToken(rawSessionToken) {
+  const sessionTokenHash = hashSessionToken(rawSessionToken);
+
+  return await db.session.findFirst({
+    where: {
+      tokenHash: sessionTokenHash,
+      expiresAt: {
+        gt: new Date(),
+      },
+    },
+    select: {
+      sessionId: true,
+      userId: true,
+      expiresAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+}
+
+async function renew(sessionId, rawSessionToken) {
+  const expiresAt = new Date(Date.now() + SESSION_DURATION_IN_MILLISECONDS);
+
+  const renewedSession = await db.session.update({
+    where: {
+      sessionId,
+    },
+    data: {
+      expiresAt,
+    },
+    select: {
+      sessionId: true,
+      userId: true,
+      expiresAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  const sessionCookie = createSessionCookie(rawSessionToken);
+
+  return {
+    session: renewedSession,
+    sessionCookie,
+  };
+}
+
+async function expireById(sessionId) {
+  return await db.session.update({
+    where: {
+      sessionId,
+    },
+    data: {
+      expiresAt: new Date(),
+    },
+    select: {
+      sessionId: true,
+      userId: true,
+      expiresAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+}
+
+function generateSessionToken() {
+  return crypto.randomBytes(48).toString("hex");
+}
+
+function hashSessionToken(sessionToken) {
+  return crypto.createHash("sha256").update(sessionToken).digest("hex");
+}
+
+function createSessionCookie(sessionToken) {
+  return cookie.serialize(SESSION_COOKIE_NAME, sessionToken, {
+    path: "/",
+    httpOnly: true,
+    sameSite: "lax",
+    maxAge: SESSION_DURATION_IN_SECONDS,
+    secure: process.env.NODE_ENV === "production",
+  });
+}
+
+const session = {
+  create,
+  findValidSessionbyToken,
+  renew,
+  expireById,
+  hashSessionToken,
+  SESSION_COOKIE_NAME,
+  SESSION_DURATION_IN_MILLISECONDS,
+  SESSION_DURATION_IN_SECONDS,
+};
+
+export default session;

--- a/src/pages/api/v1/sessions/index.js
+++ b/src/pages/api/v1/sessions/index.js
@@ -1,0 +1,104 @@
+import { createRouter } from "next-connect";
+
+import authentication from "@/infra/authentication.js";
+import controller from "@/infra/controller";
+import {
+  ForbiddenError,
+  UnauthorizedError,
+  ValidationError,
+} from "@/infra/errors";
+import session from "@/infra/session.js";
+
+const router = createRouter();
+
+router.post(postHandler);
+router.delete(deleteHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function postHandler(request, response) {
+  const { email, password } = request.body;
+
+  if (!email || !password) {
+    const publicErrorObject = new ValidationError();
+
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "Missing required fields.",
+      action: "Send email and password.",
+      status_code: 400,
+    });
+  }
+
+  const authenticatedUser = await authentication.getAuthenticatedUser({
+    email,
+    password,
+  });
+
+  if (!authenticatedUser.isActive) {
+    const publicErrorObject = new ForbiddenError();
+
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ForbiddenError",
+      message: "User is not active.",
+      action: "Contact an administrator to reactivate this user.",
+      status_code: 403,
+    });
+  }
+
+  const { session: createdSession, sessionCookie } = await session.create(
+    authenticatedUser.userId,
+  );
+
+  response.setHeader("Set-Cookie", sessionCookie);
+
+  return response.status(201).json({
+    session_id: createdSession.sessionId,
+    expires_at: createdSession.expiresAt.toISOString(),
+    created_at: createdSession.createdAt.toISOString(),
+    updated_at: createdSession.updatedAt.toISOString(),
+    user: {
+      user_id: authenticatedUser.userId,
+      username: authenticatedUser.username,
+      email: authenticatedUser.email,
+      access_level: authenticatedUser.accessLevel,
+      linked_barber_id: authenticatedUser.linkedBarberId,
+      is_active: authenticatedUser.isActive,
+      created_at: authenticatedUser.createdAt.toISOString(),
+      updated_at: authenticatedUser.updatedAt.toISOString(),
+    },
+  });
+}
+
+async function deleteHandler(request, response) {
+  const rawSessionToken = request.cookies.session_id;
+
+  if (!rawSessionToken) {
+    throw new UnauthorizedError({
+      message: "Invalid or expired session.",
+      action: "Login to continue.",
+    });
+  }
+
+  const validSessionObject =
+    await session.findValidSessionbyToken(rawSessionToken);
+
+  if (!validSessionObject) {
+    throw new UnauthorizedError({
+      message: "Invalid or expired session.",
+      action: "Login to continue.",
+    });
+  }
+
+  const expiredSession = await session.expireById(validSessionObject.sessionId);
+
+  controller.clearSessionCookie(response);
+
+  return response.status(200).json({
+    session_id: expiredSession.sessionId,
+    user_id: expiredSession.userId,
+    expires_at: expiredSession.expiresAt.toISOString(),
+    created_at: expiredSession.createdAt.toISOString(),
+    updated_at: expiredSession.updatedAt.toISOString(),
+  });
+}

--- a/src/pages/api/v1/user/index.js
+++ b/src/pages/api/v1/user/index.js
@@ -1,0 +1,81 @@
+import { createRouter } from "next-connect";
+
+import controller from "@/infra/controller";
+import { NotFoundError, UnauthorizedError } from "@/infra/errors";
+import { prisma as db } from "@/infra/prisma.js";
+import session from "@/infra/session.js";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  response.setHeader(
+    "Cache-Control",
+    "no-store, no-cache, max-age=0, must-revalidate",
+  );
+  response.setHeader("Pragma", "no-cache");
+  response.setHeader("Expires", "0");
+
+  const rawSessionToken = request.cookies.session_id;
+
+  if (!rawSessionToken) {
+    throw new UnauthorizedError({
+      message: "User not authenticated.",
+      action: "Login to access this resource.",
+    });
+  }
+
+  const validSessionObject =
+    await session.findValidSessionbyToken(rawSessionToken);
+
+  if (!validSessionObject) {
+    throw new UnauthorizedError({
+      message: "Invalid or expired session.",
+      action: "Login to continue.",
+    });
+  }
+
+  const userFound = await db.user.findUnique({
+    where: {
+      userId: validSessionObject.userId,
+    },
+    select: {
+      userId: true,
+      username: true,
+      email: true,
+      accessLevel: true,
+      linkedBarberId: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!userFound) {
+    throw new NotFoundError({
+      message: "User linked to this session was not found.",
+      action: "Login again or contact support.",
+    });
+  }
+
+  const { sessionCookie } = await session.renew(
+    validSessionObject.sessionId,
+    rawSessionToken,
+  );
+
+  response.setHeader("Set-Cookie", sessionCookie);
+
+  return response.status(200).json({
+    user_id: userFound.userId,
+    username: userFound.username,
+    email: userFound.email,
+    access_level: userFound.accessLevel,
+    linked_barber_id: userFound.linkedBarberId,
+    is_active: userFound.isActive,
+    created_at: userFound.createdAt.toISOString(),
+    updated_at: userFound.updatedAt.toISOString(),
+  });
+}

--- a/src/tests/integration/api/v1/sessions/delete.test.js
+++ b/src/tests/integration/api/v1/sessions/delete.test.js
@@ -1,0 +1,149 @@
+import crypto from "node:crypto";
+
+import { version as uuidVersion } from "uuid";
+import setCookieParser from "set-cookie-parser";
+
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import session from "@/infra/session.js";
+import webserver from "@/infra/webserver.mjs";
+
+describe("DELETE /api/v1/sessions", () => {
+  describe("Default user", () => {
+    test("With nonexistent session", async () => {
+      const nonexistentToken = crypto.randomBytes(48).toString("hex");
+
+      const response = await fetch(`${webserver.origin}/api/v1/sessions`, {
+        method: "DELETE",
+        headers: {
+          Cookie: `session_id=${nonexistentToken}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Invalid or expired session.",
+        action: "Login to continue.",
+        status_code: 401,
+      });
+    });
+
+    test("With expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(
+          Date.now() - session.SESSION_DURATION_IN_MILLISECONDS - 1000,
+        ),
+      });
+
+      const createdUser = await orchestrator.createUser();
+
+      const sessionObject = await orchestrator.createSession(
+        createdUser.userId,
+      );
+
+      jest.useRealTimers();
+
+      const response = await fetch(`${webserver.origin}/api/v1/sessions`, {
+        method: "DELETE",
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Invalid or expired session.",
+        action: "Login to continue.",
+        status_code: 401,
+      });
+    });
+
+    test("With valid session", async () => {
+      const createdUser = await orchestrator.createUser();
+
+      const sessionObject = await orchestrator.createSession(
+        createdUser.userId,
+      );
+
+      const response = await fetch(`${webserver.origin}/api/v1/sessions`, {
+        method: "DELETE",
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        session_id: sessionObject.session.sessionId,
+        user_id: createdUser.userId,
+        expires_at: responseBody.expires_at,
+        created_at: sessionObject.session.createdAt.toISOString(),
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.session_id)).toBe(4);
+      expect(uuidVersion(responseBody.user_id)).toBe(4);
+
+      expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      expect(new Date(responseBody.expires_at).getTime()).toBeLessThan(
+        sessionObject.session.expiresAt.getTime(),
+      );
+
+      expect(
+        new Date(responseBody.updated_at).getTime(),
+      ).toBeGreaterThanOrEqual(sessionObject.session.updatedAt.getTime());
+
+      const setCookieHeader = response.headers.get("set-cookie");
+
+      expect(setCookieHeader).toEqual(expect.any(String));
+
+      const parsedSetCookie = setCookieParser.parse(setCookieHeader, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual(
+        expect.objectContaining({
+          name: "session_id",
+          value: "invalid",
+          maxAge: -1,
+          path: "/",
+          httpOnly: true,
+          sameSite: "Lax",
+        }),
+      );
+
+      const doubleCheckResponse = await fetch(
+        `${webserver.origin}/api/v1/user`,
+        {
+          headers: {
+            Cookie: `session_id=${sessionObject.token}`,
+          },
+        },
+      );
+
+      expect(doubleCheckResponse.status).toBe(401);
+
+      const doubleCheckResponseBody = await doubleCheckResponse.json();
+
+      expect(doubleCheckResponseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Invalid or expired session.",
+        action: "Login to continue.",
+        status_code: 401,
+      });
+    });
+  });
+});

--- a/src/tests/integration/api/v1/sessions/post.test.js
+++ b/src/tests/integration/api/v1/sessions/post.test.js
@@ -163,16 +163,22 @@ describe("POST /api/v1/sessions", () => {
         map: true,
       });
 
-      expect(parsedSetCookie.session_id).toEqual({
-        name: "session_id",
-        value: parsedSetCookie.session_id.value,
-        maxAge: session.SESSION_DURATION_IN_SECONDS,
-        path: "/",
-        httpOnly: true,
-        sameSite: "Lax",
-      });
+      expect(parsedSetCookie.session_id).toEqual(
+        expect.objectContaining({
+          name: "session_id",
+          value: parsedSetCookie.session_id.value,
+          maxAge: session.SESSION_DURATION_IN_SECONDS,
+          path: "/",
+          httpOnly: true,
+          sameSite: "Lax",
+        }),
+      );
 
       expect(parsedSetCookie.session_id.value).toEqual(expect.any(String));
+
+      if (setCookieHeader.includes("Secure")) {
+        expect(parsedSetCookie.session_id.secure).toBe(true);
+      }
     });
   });
 });

--- a/src/tests/integration/api/v1/sessions/post.test.js
+++ b/src/tests/integration/api/v1/sessions/post.test.js
@@ -1,0 +1,178 @@
+import { version as uuidVersion } from "uuid";
+import setCookieParser from "set-cookie-parser";
+
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+import session from "@/infra/session";
+
+const endPoint = "sessions";
+
+describe("POST /api/v1/sessions", () => {
+  describe("Anonymous user", () => {
+    test("With incorrect `email`, but correct `password`", async () => {
+      await orchestrator.createUser({
+        password: "senha_correta",
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/${endPoint}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "email.wrong@test.com",
+          password: "senha_correta",
+        }),
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Invalid email or password.",
+        action: "Check your credentials and try again.",
+        status_code: 401,
+      });
+    });
+
+    test("With correct `email`, but incorrect `password`", async () => {
+      await orchestrator.createUser({
+        email: "email.correct@test.com",
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/${endPoint}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "email.correct@test.com",
+          password: "wrong_password",
+        }),
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Invalid email or password.",
+        action: "Check your credentials and try again.",
+        status_code: 401,
+      });
+    });
+
+    test("With incorrect `email` and `password`", async () => {
+      await orchestrator.createUser({
+        email: "email.wrong@test.com",
+        password: "wrong_password",
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/${endPoint}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "email.correct@test.com",
+          password: "correct_password",
+        }),
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Invalid email or password.",
+        action: "Check your credentials and try again.",
+        status_code: 401,
+      });
+    });
+
+    test("With correct `email` and `password`", async () => {
+      const createdUser = await orchestrator.createUser({
+        email: "email.eveythingcorrect@test.com",
+        password: "everything_correct_password",
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/${endPoint}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "email.eveythingcorrect@test.com",
+          password: "everything_correct_password",
+        }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        session_id: responseBody.session_id,
+        expires_at: responseBody.expires_at,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        user: {
+          user_id: createdUser.userId,
+          username: createdUser.username,
+          email: "email.eveythingcorrect@test.com",
+          access_level: createdUser.accessLevel,
+          linked_barber_id: null,
+          is_active: true,
+          created_at: responseBody.user.created_at,
+          updated_at: responseBody.user.updated_at,
+        },
+      });
+
+      // Checks for the responseBody
+      expect(uuidVersion(responseBody.user.user_id)).toBe(4);
+      expect(responseBody.session_id).toEqual(expect.any(String));
+      expect(Date.parse(responseBody.expires_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      expect(responseBody.user.user_id).toEqual(expect.any(String));
+      expect(Date.parse(responseBody.user.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.user.updated_at)).not.toBeNaN();
+
+      // Checks if the expires_at date is greater than the created_at date (expect true)
+      const expires_at = new Date(responseBody.expires_at);
+      const created_at = new Date(responseBody.created_at);
+
+      expires_at.setMilliseconds(0);
+      created_at.setMilliseconds(0);
+
+      expect(expires_at - created_at).toBe(
+        session.SESSION_DURATION_IN_MILLISECONDS,
+      );
+
+      // Checks the Cookie properties
+      const setCookieHeader = response.headers.get("set-cookie");
+
+      expect(setCookieHeader).toEqual(expect.any(String));
+
+      const parsedSetCookie = setCookieParser.parse(setCookieHeader, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: parsedSetCookie.session_id.value,
+        maxAge: session.SESSION_DURATION_IN_SECONDS,
+        path: "/",
+        httpOnly: true,
+        sameSite: "Lax",
+      });
+
+      expect(parsedSetCookie.session_id.value).toEqual(expect.any(String));
+    });
+  });
+});

--- a/src/tests/integration/api/v1/user/get.test.js
+++ b/src/tests/integration/api/v1/user/get.test.js
@@ -1,0 +1,237 @@
+import crypto from "node:crypto";
+
+import * as cookie from "cookie";
+import { version as uuidVersion } from "uuid";
+import setCookieParser from "set-cookie-parser";
+
+import webserver from "@/infra/webserver.mjs";
+import session from "@/infra/session.js";
+import { prisma as db } from "@/infra/prisma.js";
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+
+describe("GET /api/v1/user", () => {
+  describe("Default user", () => {
+    test("With valid session", async () => {
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithValidSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(
+        createdUser.userId,
+      );
+
+      const sessionBeforeRenewal = await db.session.update({
+        where: {
+          sessionId: sessionObject.session.sessionId,
+        },
+        data: {
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000), // 1 hour from now
+        },
+        select: {
+          sessionId: true,
+          userId: true,
+          updatedAt: true,
+          expiresAt: true,
+        },
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/user`, {
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        user_id: createdUser.userId,
+        username: createdUser.username,
+        email: createdUser.email,
+        access_level: createdUser.accessLevel,
+        linked_barber_id: createdUser.linkedBarberId,
+        is_active: createdUser.isActive,
+        created_at: createdUser.createdAt.toISOString(),
+        updated_at: createdUser.updatedAt.toISOString(),
+      });
+
+      expect(uuidVersion(responseBody.user_id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      const renewedSessionObject = await db.session.findUnique({
+        where: {
+          sessionId: sessionObject.session.sessionId,
+        },
+        select: {
+          sessionId: true,
+          userId: true,
+          updatedAt: true,
+          expiresAt: true,
+        },
+      });
+
+      expect(renewedSessionObject.expiresAt.getTime()).toBeGreaterThan(
+        sessionBeforeRenewal.expiresAt.getTime(),
+      );
+
+      expect(renewedSessionObject.updatedAt.getTime()).toBeGreaterThanOrEqual(
+        sessionBeforeRenewal.updatedAt.getTime(),
+      );
+
+      const setCookieHeader = response.headers.get("set-cookie");
+
+      expect(setCookieHeader).toEqual(expect.any(String));
+
+      const parsedSetCookie = cookie.parse(setCookieHeader);
+
+      expect(parsedSetCookie.session_id).toEqual(expect.any(String));
+      expect(setCookieHeader).toContain("HttpOnly");
+      expect(setCookieHeader).toContain("Path=/");
+      expect(setCookieHeader).toContain(
+        `Max-Age=${session.SESSION_DURATION_IN_SECONDS}`,
+      );
+      expect(setCookieHeader).toContain("SameSite=Lax");
+    });
+
+    test("With nonexistent session", async () => {
+      const nonexistentToken = crypto.randomBytes(48).toString("hex");
+
+      const response = await fetch(`${webserver.origin}/api/v1/user`, {
+        headers: {
+          Cookie: `session_id=${nonexistentToken}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Invalid or expired session.",
+        action: "Login to continue.",
+        status_code: 401,
+      });
+    });
+
+    test("With session about to expire", async () => {
+      const extraTime = 1000; // 1 second
+
+      jest.useFakeTimers({
+        now: new Date(
+          Date.now() - session.SESSION_DURATION_IN_MILLISECONDS + extraTime,
+        ),
+      });
+
+      const createdUser = await orchestrator.createUser({
+        username: "SessionAboutToBeInvalid",
+      });
+
+      const sessionObject = await orchestrator.createSession(
+        createdUser.userId,
+      );
+
+      jest.useRealTimers();
+
+      const response = await fetch(`${webserver.origin}/api/v1/user`, {
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      // Check if caching is disabled for this endpoint
+      const cacheControl = response.headers.get("Cache-Control");
+      expect(cacheControl).toBe(
+        "no-store, no-cache, max-age=0, must-revalidate",
+      );
+      expect(response.headers.get("cache-control")).toContain("no-store");
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        user_id: createdUser.userId,
+        username: "SessionAboutToBeInvalid",
+        email: createdUser.email,
+        access_level: createdUser.accessLevel,
+        linked_barber_id: createdUser.linkedBarberId,
+        is_active: createdUser.isActive,
+        created_at: createdUser.createdAt.toISOString(),
+        updated_at: createdUser.updatedAt.toISOString(),
+      });
+
+      expect(uuidVersion(responseBody.user_id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      const renewedSessionObject = await session.findValidSessionbyToken(
+        sessionObject.token,
+      );
+
+      expect(renewedSessionObject).not.toBeNull();
+
+      expect(renewedSessionObject.expiresAt.getTime()).toBeGreaterThan(
+        sessionObject.session.expiresAt.getTime(),
+      );
+
+      expect(renewedSessionObject.updatedAt.getTime()).toBeGreaterThanOrEqual(
+        sessionObject.session.updatedAt.getTime(),
+      );
+
+      const setCookieHeader = response.headers.get("set-cookie");
+
+      expect(setCookieHeader).toEqual(expect.any(String));
+
+      const parsedSetCookie = setCookieParser.parse(setCookieHeader, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual(
+        expect.objectContaining({
+          name: "session_id",
+          value: sessionObject.token,
+          maxAge: session.SESSION_DURATION_IN_SECONDS,
+          path: "/",
+          httpOnly: true,
+          sameSite: "Lax",
+        }),
+      );
+    });
+
+    test("With expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(Date.now() - session.SESSION_DURATION_IN_MILLISECONDS),
+      });
+
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithExpiredSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(
+        createdUser.userId,
+      );
+
+      jest.useRealTimers();
+
+      const response = await fetch(`${webserver.origin}/api/v1/user`, {
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Invalid or expired session.",
+        action: "Login to continue.",
+        status_code: 401,
+      });
+    });
+  });
+});

--- a/src/tests/orchestrator/orchestrator.mjs
+++ b/src/tests/orchestrator/orchestrator.mjs
@@ -1,11 +1,13 @@
 import { execFileSync } from "node:child_process";
 
+import * as cookie from "cookie";
 import retry from "async-retry";
 import { faker } from "@faker-js/faker";
 
 import webserver from "../../infra/webserver.mjs";
 import { prisma as db } from "../../infra/prisma.js";
 import password from "../../infra/password.js";
+import session from "../../infra/session.js";
 
 // const emailHttpUrl = `http://${process.env.EMAIL_HTTP_HOST}:${process.env.EMAIL_HTTP_PORT}`;
 
@@ -123,10 +125,28 @@ async function createUser(userObject = {}) {
   });
 }
 
+async function createSession(userId) {
+  const sessionObject = await session.create(userId);
+
+  const parsedCookie = cookie.parse(sessionObject.sessionCookie);
+
+  const rawSessionToken = parsedCookie.session_id || parsedCookie.session_token;
+
+  if (!rawSessionToken) {
+    throw new Error("Could not extract raw session token from session cookie.");
+  }
+
+  return {
+    ...sessionObject,
+    token: rawSessionToken,
+  };
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
   createUser,
+  createSession,
 };
 
 export default orchestrator;


### PR DESCRIPTION
## Summary

This PR implements the session-based authorization flow for the API.

It adds persistent user sessions, login/logout endpoints, an authenticated current-user endpoint, session cookies, session renewal, and integration tests covering the main authentication scenarios.

## Main changes

- Added `Session` model to Prisma
  - Stores hashed session tokens
  - Links sessions to users
  - Tracks expiration dates
  - Adds indexes for user/session lookup

- Added session infrastructure
  - Generates secure raw session tokens
  - Stores only hashed session tokens in the database
  - Creates HTTP-only session cookies
  - Supports valid session lookup, renewal, and expiration

- Added credential authentication helper
  - Authenticates users by email and password
  - Normalizes email before lookup
  - Uses fake password hashes to reduce timing differences between invalid email and invalid password cases

- Added `POST /api/v1/sessions`
  - Authenticates users
  - Blocks inactive users
  - Creates sessions
  - Returns session and user data
  - Sets the `session_id` cookie

- Added `DELETE /api/v1/sessions`
  - Validates the current session
  - Expires the session
  - Clears the session cookie

- Added `GET /api/v1/user`
  - Returns the currently authenticated user
  - Validates the session cookie
  - Renews valid sessions
  - Disables caching for authenticated user data

- Updated controller behavior
  - Handles authorization-related public errors
  - Clears the session cookie when an unauthorized error occurs

- Updated test orchestrator
  - Added helper to create sessions for integration tests

## Tests

Added integration coverage for:

- login with invalid credentials
- login with valid credentials
- session cookie creation
- logout with valid sessions
- logout with expired/nonexistent sessions
- current user lookup with valid sessions
- current user lookup with expired/nonexistent sessions
- session renewal
- cache-control headers for authenticated user responses

## Notes

Session tokens are stored as hashes in the database, while the raw token is only sent to the client through an HTTP-only cookie.