### PR TITLE
feat(api): add authorization layer and scheduling endpoints

### DIFF
--- a/docs/AUTHORIZATION_IMPLEMENTATION_GUIDE.md
+++ b/docs/AUTHORIZATION_IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,655 @@
+# Authorization Implementation Guide
+
+## Project context
+
+This project is a barbershop appointment system built with:
+
+- Next.js Pages Router (`src/pages`)
+- JavaScript
+- Prisma ORM
+- PostgreSQL
+- Session-based authentication using database-backed sessions
+- API routes under `src/pages/api/v1/...`
+
+Authentication is already mostly implemented through:
+
+- `src/infra/authentication.js`
+- `src/infra/session.js`
+- `src/pages/api/v1/sessions/index.js`
+- `src/pages/api/v1/user/index.js`
+
+The next step is to implement authorization.
+
+Authorization must answer:
+
+> The user is authenticated, but is this user allowed to perform this action?
+
+---
+
+## User categories
+
+### Admin
+
+Admins have full access.
+
+Rules:
+
+- Admin can access every authenticated feature.
+- Admin can manage users, barbers, services, appointments, and clients.
+- Admin bypasses ownership checks.
+
+In Prisma, this is represented by:
+
+```prisma
+enum AccessLevel {
+  admin
+  barber
+}
+```
+
+### Barber
+
+Barbers are authenticated users with limited permissions.
+
+Rules:
+
+- Barbers can access dashboard features intended for them.
+- Barbers can only access or modify resources related to their own barber profile.
+- Ownership is determined through `User.linkedBarberId`.
+
+Example:
+
+```js
+user.linkedBarberId === appointment.barberId;
+```
+
+### Client
+
+Clients do not log in.
+
+Rules:
+
+- Clients only access public features.
+- Public features include the appointment maker page `src/pages/appointment/emperor-barbershop.jsx` and appointment summary `src/pages/appointment/summary.jsx`.
+- Client-facing routes should not require authentication unless explicitly changed later.
+
+---
+
+## Authorization strategy
+
+Use a simple hybrid model:
+
+```txt
+Role-based permissions
++
+Resource ownership checks
+```
+
+Do not create database permission tables yet.
+
+This project only has two authenticated roles (`admin` and `barber`), so static permissions in code are simpler, clearer, and easier to test.
+
+---
+
+## Recommended authorization flow
+
+For protected API routes:
+
+```txt
+1. Request arrives.
+
+2. Is the route public?
+   - yes → allow without authentication.
+   - no → require authenticated user.
+
+3. Is the authenticated user admin?
+   - yes → allow.
+
+4. Does the user have permission for this feature/action?
+   - no → throw ForbiddenError.
+
+5. If this is a resource-specific action, does the user own the resource?
+   - yes → allow.
+   - no → throw ForbiddenError.
+```
+
+Admin should be checked early because admin has global access.
+
+---
+
+## New file to create
+
+Create:
+
+```txt
+src/infra/authorization.js
+```
+
+This file should contain authorization-only logic.
+
+Do not put authorization logic directly inside API routes unless it is very small and endpoint-specific.
+
+---
+
+## Recommended `authorization.js` responsibilities
+
+The file should export an object like:
+
+```js
+const authorization = {
+  isAdmin,
+  hasPermission,
+  ensurePermission,
+  ensureOwnerOrAdmin,
+};
+
+export default authorization;
+```
+
+### Required functions
+
+#### `isAdmin(user)`
+
+Returns `true` if:
+
+```js
+user.accessLevel === "admin";
+```
+
+#### `hasPermission(user, permission)`
+
+Returns whether a user has a specific permission.
+
+Admin should always return `true`.
+
+#### `ensurePermission(user, permission)`
+
+Throws `ForbiddenError` if the user does not have permission.
+
+#### `ensureOwnerOrAdmin(user, resourceOwnerBarberId)`
+
+Allows access when:
+
+```js
+user.accessLevel === "admin";
+```
+
+or:
+
+```js
+user.linkedBarberId === resourceOwnerBarberId;
+```
+
+Otherwise throws `ForbiddenError`.
+
+---
+
+## Suggested initial permissions
+
+Start small. Do not create too many permissions upfront.
+
+Recommended map:
+
+```js
+const permissions = {
+  admin: ["*"],
+
+  barber: [
+    "dashboard:read",
+    "appointments:read-own",
+    "appointments:update-own",
+    "barbers:read-own",
+    "services:read",
+  ],
+};
+```
+
+Add new permissions only when an endpoint actually needs them.
+
+---
+
+## Suggested implementation for `authorization.js`
+
+```js
+import { ForbiddenError } from "@/infra/errors";
+
+const permissions = {
+  admin: ["*"],
+
+  barber: [
+    "dashboard:read",
+    "appointments:read-own",
+    "appointments:update-own",
+    "barbers:read-own",
+    "services:read",
+  ],
+};
+
+function isAdmin(user) {
+  return user?.accessLevel === "admin";
+}
+
+function hasPermission(user, permission) {
+  if (!user) {
+    return false;
+  }
+
+  if (isAdmin(user)) {
+    return true;
+  }
+
+  const userPermissions = permissions[user.accessLevel] || [];
+
+  return userPermissions.includes(permission);
+}
+
+function ensurePermission(user, permission) {
+  if (hasPermission(user, permission)) {
+    return;
+  }
+
+  throw new ForbiddenError({
+    message: "You do not have permission to access this feature.",
+    action: "Contact an administrator if you believe this access is required.",
+  });
+}
+
+function ensureOwnerOrAdmin(user, resourceOwnerBarberId) {
+  if (isAdmin(user)) {
+    return;
+  }
+
+  if (user?.linkedBarberId && user.linkedBarberId === resourceOwnerBarberId) {
+    return;
+  }
+
+  throw new ForbiddenError({
+    message: "You do not have permission to access this resource.",
+    action: "Verify if this resource belongs to your user.",
+  });
+}
+
+function ensureAdmin(user) {
+  if (isAdmin(user)) {
+    return;
+  }
+
+  throw new ForbiddenError({
+    message: "Only administrators can perform this action.",
+    action: "Login with an administrator account.",
+  });
+}
+
+const authorization = {
+  isAdmin,
+  hasPermission,
+  ensurePermission,
+  ensureOwnerOrAdmin,
+  ensureAdmin,
+};
+
+export default authorization;
+```
+
+---
+
+## Authentication helper needed
+
+The project already has session lookup logic in:
+
+```txt
+src/pages/api/v1/user/index.js
+```
+
+That logic should eventually be reused by protected endpoints.
+
+Recommended future refactor:
+
+```js
+authentication.getAuthenticatedUserFromRequest(request);
+```
+
+or:
+
+```js
+session.getAuthenticatedUserFromRequest(request);
+```
+
+This helper should:
+
+1. Read `session_id` cookie.
+2. Validate the session.
+3. Find the user.
+4. Return the authenticated user.
+5. Throw `UnauthorizedError` if the session is missing, invalid, or expired.
+
+This prevents repeating cookie/session/user lookup in every endpoint.
+
+---
+
+## Endpoint protection examples
+
+### Admin-only endpoint
+
+For endpoints like:
+
+```txt
+PATCH /api/v1/users/[username]
+POST /api/v1/users
+```
+
+Use:
+
+```js
+const authenticatedUser =
+  await authentication.getAuthenticatedUserFromRequest(request);
+
+authorization.ensureAdmin(authenticatedUser);
+```
+
+or, if using named permissions:
+
+```js
+authorization.ensurePermission(authenticatedUser, "users:update");
+```
+
+### Barber-owned appointment
+
+For an endpoint like:
+
+```txt
+PATCH /api/v1/appointments/[appointmentId]
+```
+
+Suggested flow:
+
+```js
+const authenticatedUser = await authentication.getAuthenticatedUserFromRequest(request);
+
+authorization.ensurePermission(authenticatedUser, "appointments:update-own");
+
+const appointment = await prisma.appointment.findUnique({
+  where: { appointmentId },
+  select: {
+    appointmentId: true,
+    barberId: true,
+  },
+});
+
+if (!appointment) {
+  throw new NotFoundError(...);
+}
+
+authorization.ensureOwnerOrAdmin(authenticatedUser, appointment.barberId);
+```
+
+Admin passes automatically. Barber only passes if the appointment belongs to their linked barber profile.
+
+---
+
+## Ownership rules
+
+### Appointment ownership
+
+A barber owns an appointment when:
+
+```js
+user.linkedBarberId === appointment.barberId;
+```
+
+### Barber ownership
+
+A barber owns a barber profile when:
+
+```js
+user.linkedBarberId === barber.barberId;
+```
+
+### Service ownership
+
+Services are barbershop-level resources.
+
+Recommended rule for now:
+
+```txt
+admin → create/update/delete services
+barber → read services
+public/client → read active services for booking flow
+```
+
+### Client ownership
+
+Clients are not authenticated users in the current model.
+
+Recommended rule for now:
+
+```txt
+admin → manage clients
+barber → maybe read clients connected to own appointments later
+public/client → no direct client management
+```
+
+Do not overbuild this yet.
+
+---
+
+## Public routes
+
+These should remain unauthenticated:
+
+```txt
+Appointment maker page
+Appointment summary page
+Public service listing
+Public barber listing
+Public appointment creation, if that is part of the booking flow
+```
+
+Public appointment creation should still validate business rules, such as:
+
+- barber exists
+- service exists
+- appointment is not in the past
+- no overlapping appointments
+- appointment is inside working hours
+
+Authentication is not required for public booking.
+
+---
+
+## Backend-first authorization
+
+Frontend access control is useful for UX, but it is not security.
+
+The API must enforce authorization.
+
+Example:
+
+- Hide admin buttons in React.
+- Also protect the corresponding API endpoint.
+
+Never rely only on frontend checks.
+
+---
+
+## Recommended implementation order
+
+### Step 1
+
+Create:
+
+```txt
+src/infra/authorization.js
+```
+
+with:
+
+- `isAdmin`
+- `hasPermission`
+- `ensurePermission`
+- `ensureOwnerOrAdmin`
+- optionally `ensureAdmin`
+
+### Step 2
+
+Add or refactor a reusable authenticated user helper.
+
+Suggested name:
+
+```js
+authentication.getAuthenticatedUserFromRequest(request);
+```
+
+or:
+
+```js
+session.getAuthenticatedUserFromRequest(request);
+```
+
+Prefer keeping identity/session logic outside API route files.
+
+### Step 3
+
+Protect one simple endpoint first.
+
+Recommended first endpoint:
+
+```txt
+PATCH /api/v1/users/[username]
+```
+
+Make it admin-only.
+
+### Step 4
+
+Add tests for the protected endpoint.
+
+Test cases:
+
+```txt
+anonymous user → 401 UnauthorizedError
+barber user → 403 ForbiddenError
+admin user → allowed
+```
+
+### Step 5
+
+Protect a resource-owned endpoint later.
+
+Recommended resource-owned feature:
+
+```txt
+appointments
+```
+
+Test cases:
+
+```txt
+barber accessing own appointment → allowed
+barber accessing another barber appointment → 403
+admin accessing any appointment → allowed
+```
+
+---
+
+## Error behavior
+
+Use existing error classes from:
+
+```txt
+src/infra/errors.js
+```
+
+Expected mapping:
+
+```txt
+Missing/invalid session → UnauthorizedError → 401
+Authenticated but not allowed → ForbiddenError → 403
+Resource does not exist → NotFoundError → 404
+Invalid input → ValidationError → 400
+```
+
+Do not use `UnauthorizedError` for permission failures. Use `ForbiddenError`.
+
+Difference:
+
+```txt
+401 Unauthorized → user is not authenticated
+403 Forbidden    → user is authenticated but not allowed
+```
+
+---
+
+## Testing guidance
+
+Use the orchestrator for setup.
+
+Recommended helper additions, if not already present:
+
+```js
+orchestrator.createUser({
+  accessLevel: "admin",
+});
+
+orchestrator.createUser({
+  accessLevel: "barber",
+  linkedBarberId: barber.barberId,
+});
+
+orchestrator.createSession(user.userId);
+```
+
+When testing protected endpoints:
+
+1. Create user.
+2. Create session.
+3. Send cookie:
+
+```js
+headers: {
+  Cookie: `session_id=${sessionObject.token}`,
+}
+```
+
+Use direct Prisma/orchestrator setup for resources. Only use HTTP `fetch()` for the endpoint under test.
+
+---
+
+## Important security notes
+
+- Do not expose `passwordHash`.
+- Do not return raw session tokens in JSON.
+- Session tokens should only be sent through `HttpOnly` cookies.
+- Use `ForbiddenError` for authorization failures.
+- Protected endpoints should disable caching when response/session renewal depends on request state.
+
+Recommended header for user/session-dependent GET endpoints:
+
+```js
+response.setHeader(
+  "Cache-Control",
+  "no-store, no-cache, must-revalidate, proxy-revalidate",
+);
+response.setHeader("Pragma", "no-cache");
+response.setHeader("Expires", "0");
+```
+
+---
+
+## Final expected architecture
+
+```txt
+src/infra/authentication.js
+  → identify user / validate credentials / maybe get authenticated user from request
+
+src/infra/session.js
+  → create, find, renew, expire sessions
+
+src/infra/authorization.js
+  → permissions and ownership checks
+
+src/pages/api/v1/...
+  → HTTP request/response, validation, calls infra/services
+```
+
+The goal is simple and robust authorization, not enterprise-level permission complexity.

--- a/src/infra/authentication.js
+++ b/src/infra/authentication.js
@@ -1,6 +1,7 @@
-import { UnauthorizedError } from "@/infra/errors";
+import { UnauthorizedError, NotFoundError } from "@/infra/errors";
 import password from "@/infra/password.js";
 import { prisma as db } from "@/infra/prisma.js";
+import session from "@/infra/session.js";
 
 // Used to reduce timing differences between:
 // - email not found
@@ -55,6 +56,62 @@ async function getAuthenticatedUser({
   return storedUser;
 }
 
+async function getAuthenticatedUserFromRequest(request) {
+  const rawSessionToken = request.cookies.session_id;
+
+  if (!rawSessionToken) {
+    throw new UnauthorizedError({
+      message: "User not authenticated.",
+      action: "Login to access this resource.",
+    });
+  }
+
+  const validSessionObject =
+    await session.findValidSessionbyToken(rawSessionToken);
+
+  if (!validSessionObject) {
+    throw new UnauthorizedError({
+      message: "Invalid or expired session.",
+      action: "Login to continue.",
+    });
+  }
+
+  const userFound = await db.user.findUnique({
+    where: {
+      userId: validSessionObject.userId,
+    },
+    select: {
+      userId: true,
+      username: true,
+      email: true,
+      accessLevel: true,
+      linkedBarberId: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!userFound) {
+    throw new NotFoundError({
+      message: "User linked to this session was not found.",
+      action: "Login again or contact support.",
+    });
+  }
+
+  if (!userFound.isActive) {
+    throw new UnauthorizedError({
+      message: "User account is not active.",
+      action: "Contact support to reactivate this account.",
+    });
+  }
+
+  return {
+    user: userFound,
+    session: validSessionObject,
+  };
+}
+
 function getFakePasswordHash() {
   if (process.env.NODE_ENV === "production") {
     return FAKE_PASSWORD_HASH_PRODUCTION;
@@ -65,6 +122,7 @@ function getFakePasswordHash() {
 
 const authentication = {
   getAuthenticatedUser,
+  getAuthenticatedUserFromRequest,
 };
 
 export default authentication;

--- a/src/infra/authorization.js
+++ b/src/infra/authorization.js
@@ -1,0 +1,39 @@
+import { ForbiddenError } from "@/infra/errors";
+
+function isAdmin(user) {
+  return user?.accessLevel === "admin";
+}
+
+function ensureAdmin(user) {
+  if (isAdmin(user)) {
+    return;
+  }
+
+  throw new ForbiddenError({
+    message: "This action requires admin access.",
+    action: "Contact an administrator.",
+  });
+}
+
+function ensureOwnerOrAdmin(user, resourceOwnerBarberId) {
+  if (isAdmin(user)) {
+    return;
+  }
+
+  if (user?.linkedBarberId && user.linkedBarberId === resourceOwnerBarberId) {
+    return;
+  }
+
+  throw new ForbiddenError({
+    message: "You do not have permission to access this resource.",
+    action: "Verify if your user has access to this resource.",
+  });
+}
+
+const authorization = {
+  isAdmin,
+  ensureAdmin,
+  ensureOwnerOrAdmin,
+};
+
+export default authorization;

--- a/src/infra/controller.js
+++ b/src/infra/controller.js
@@ -6,6 +6,7 @@ import {
   ValidationError,
   NotFoundError,
   UnauthorizedError,
+  ForbiddenError,
 } from "./errors.js";
 
 function onNoMatchHandler(request, response) {
@@ -20,6 +21,10 @@ function onErrorHandler(error, request, response) {
 
   if (error instanceof UnauthorizedError) {
     clearSessionCookie(response);
+    return response.status(error.statusCode).json(error);
+  }
+
+  if (error instanceof ForbiddenError) {
     return response.status(error.statusCode).json(error);
   }
 

--- a/src/pages/api/v1/appointments/index.js
+++ b/src/pages/api/v1/appointments/index.js
@@ -1,0 +1,365 @@
+import { createRouter } from "next-connect";
+
+import authentication from "@/infra/authentication";
+import authorization from "@/infra/authorization";
+import controller from "@/infra/controller";
+import { ValidationError, NotFoundError, ForbiddenError } from "@/infra/errors";
+import { prisma as db } from "@/infra/prisma.js";
+
+const router = createRouter();
+
+router.post(postHandler);
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function postHandler(request, response) {
+  const {
+    barber_id,
+    appointment_datetime,
+    service_ids,
+    client_name,
+    client_phone,
+  } = request.body;
+
+  // Validation: required fields
+  if (!barber_id) {
+    const publicErrorObject = new ValidationError();
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "barber_id is required.",
+      action: "Provide a valid barber_id.",
+      status_code: 400,
+    });
+  }
+
+  if (!appointment_datetime) {
+    const publicErrorObject = new ValidationError();
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "appointment_datetime is required.",
+      action: "Provide a valid ISO8601 datetime.",
+      status_code: 400,
+    });
+  }
+
+  if (!service_ids) {
+    const publicErrorObject = new ValidationError();
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "service_ids is required.",
+      action: "Provide an array of service IDs.",
+      status_code: 400,
+    });
+  }
+
+  if (!Array.isArray(service_ids) || service_ids.length === 0) {
+    const publicErrorObject = new ValidationError();
+
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "service_ids must be a non-empty array.",
+      action: "Provide at least one service ID.",
+      status_code: 400,
+    });
+  }
+
+  if (
+    !client_name ||
+    typeof client_name !== "string" ||
+    client_name.trim() === ""
+  ) {
+    const publicErrorObject = new ValidationError();
+
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "client_name is required and cannot be empty.",
+      action: "Provide a valid client name.",
+      status_code: 400,
+    });
+  }
+
+  // Validate datetime is valid
+  const appointmentDateTime = new Date(appointment_datetime);
+  if (isNaN(appointmentDateTime.getTime())) {
+    const publicErrorObject = new ValidationError();
+
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "appointment_datetime must be a valid ISO8601 date.",
+      action: "Provide a valid ISO8601 datetime.",
+      status_code: 400,
+    });
+  }
+
+  // Validate datetime is not in the past
+  if (appointmentDateTime < new Date()) {
+    const publicErrorObject = new ValidationError();
+
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "appointment_datetime cannot be in the past.",
+      action: "Provide a future appointment date.",
+      status_code: 400,
+    });
+  }
+
+  // Validation: barber exists and is active
+  const barber = await db.barber.findUnique({
+    where: { barberId: barber_id },
+    select: { barberId: true, isActive: true },
+  });
+
+  if (!barber) {
+    throw new NotFoundError({
+      message: "Barber not found.",
+      action: "Verify the barber_id.",
+    });
+  }
+
+  if (!barber.isActive) {
+    const publicErrorObject = new ValidationError();
+
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "Barber is not active.",
+      action: "Select an active barber.",
+      status_code: 400,
+    });
+  }
+
+  // Check for duplicate service IDs
+  const uniqueServiceIds = Array.from(new Set(service_ids));
+  if (uniqueServiceIds.length !== service_ids.length) {
+    const publicErrorObject = new ValidationError();
+
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: "Duplicate service IDs are not allowed.",
+      action: "Remove duplicate service IDs.",
+      status_code: 400,
+    });
+  }
+
+  // Validation: all services exist and are active
+  const services = await db.service.findMany({
+    where: {
+      serviceId: { in: uniqueServiceIds },
+    },
+    select: {
+      serviceId: true,
+      serviceName: true,
+      isActive: true,
+      duration: true,
+      price: true,
+    },
+  });
+
+  if (services.length !== uniqueServiceIds.length) {
+    throw new NotFoundError({
+      message: "One or more services not found.",
+      action: "Verify the service IDs.",
+    });
+  }
+
+  const inactiveService = services.find((s) => !s.isActive);
+  if (inactiveService) {
+    const publicErrorObject = new ValidationError();
+
+    return response.status(publicErrorObject.statusCode).json({
+      name: "ValidationError",
+      message: `Service "${inactiveService.serviceName}" is not active.`,
+      action: "Select only active services.",
+      status_code: 400,
+    });
+  }
+
+  // Calculate total duration and end datetime
+  const totalDuration = services.reduce((sum, s) => sum + s.duration, 0);
+  const appointmentEndDatetime = new Date(
+    appointmentDateTime.getTime() + totalDuration * 60 * 1000,
+  );
+
+  try {
+    // Use transaction for atomicity
+    const result = await db.$transaction(async (tx) => {
+      // Create client
+      const client = await tx.client.create({
+        data: {
+          clientName: client_name.trim(),
+          clientPhone: client_phone || null,
+          isActive: true,
+        },
+        select: {
+          clientId: true,
+        },
+      });
+
+      // Create appointment
+      const appointment = await tx.appointment.create({
+        data: {
+          appointmentDatetime: appointmentDateTime,
+          appointmentEndDatetime: appointmentEndDatetime,
+          totalDuration,
+          status: "AGENDADO",
+          clientId: client.clientId,
+          barberId: barber_id,
+        },
+        select: {
+          appointmentId: true,
+          appointmentDatetime: true,
+          appointmentEndDatetime: true,
+          totalDuration: true,
+          status: true,
+          clientId: true,
+          barberId: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+
+      // Create appointment services
+      await tx.appointmentService.createMany({
+        data: services.map((service) => ({
+          appointmentId: appointment.appointmentId,
+          serviceId: service.serviceId,
+          servicePrice: service.price,
+          serviceDuration: service.duration,
+        })),
+      });
+
+      return {
+        appointment,
+        services,
+      };
+    });
+
+    return response.status(201).json({
+      appointment_id: result.appointment.appointmentId,
+      appointment_datetime:
+        result.appointment.appointmentDatetime.toISOString(),
+      appointment_end_datetime:
+        result.appointment.appointmentEndDatetime.toISOString(),
+      total_duration: result.appointment.totalDuration,
+      status: result.appointment.status,
+      client_id: result.appointment.clientId,
+      barber_id: result.appointment.barberId,
+      created_at: result.appointment.createdAt.toISOString(),
+      updated_at: result.appointment.updatedAt.toISOString(),
+      services: result.services.map((service) => ({
+        service_id: service.serviceId,
+        service_name: service.serviceName,
+        service_price: Number(service.price).toFixed(2),
+        service_duration: service.duration,
+      })),
+    });
+  } catch (error) {
+    // Handle unique constraint violation (duplicate barber + datetime)
+    if (error.code === "P2002") {
+      const publicErrorObject = new ValidationError();
+
+      return response.status(publicErrorObject.statusCode).json({
+        name: "ValidationError",
+        message: "An appointment already exists for this barber at this time.",
+        action: "Choose a different date or time.",
+        status_code: 400,
+      });
+    }
+
+    throw error;
+  }
+}
+
+async function getHandler(request, response) {
+  response.setHeader(
+    "Cache-Control",
+    "no-store, no-cache, max-age=0, must-revalidate",
+  );
+
+  const { user } =
+    await authentication.getAuthenticatedUserFromRequest(request);
+
+  // Determine filter based on user role
+  let whereClause = {};
+
+  if (!authorization.isAdmin(user)) {
+    // Barber must have linkedBarberId to see appointments
+    if (!user.linkedBarberId) {
+      throw new ForbiddenError({
+        message: "Barber profile not linked. Cannot access appointments.",
+        action: "Contact an administrator.",
+      });
+    }
+
+    whereClause.barberId = user.linkedBarberId;
+  }
+
+  const appointments = await db.appointment.findMany({
+    where: whereClause,
+    select: {
+      appointmentId: true,
+      appointmentDatetime: true,
+      appointmentEndDatetime: true,
+      totalDuration: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
+      client: {
+        select: {
+          clientId: true,
+          clientName: true,
+          clientPhone: true,
+        },
+      },
+      barber: {
+        select: {
+          barberId: true,
+          barberName: true,
+        },
+      },
+      appointmentServices: {
+        select: {
+          serviceId: true,
+          service: {
+            select: {
+              serviceName: true,
+            },
+          },
+          servicePrice: true,
+          serviceDuration: true,
+        },
+      },
+    },
+    orderBy: {
+      appointmentDatetime: "asc",
+    },
+  });
+
+  return response.status(200).json(
+    appointments.map((appointment) => ({
+      appointment_id: appointment.appointmentId,
+      appointment_datetime: appointment.appointmentDatetime.toISOString(),
+      appointment_end_datetime:
+        appointment.appointmentEndDatetime.toISOString(),
+      total_duration: appointment.totalDuration,
+      status: appointment.status,
+      created_at: appointment.createdAt.toISOString(),
+      updated_at: appointment.updatedAt.toISOString(),
+      client: {
+        client_id: appointment.client.clientId,
+        client_name: appointment.client.clientName,
+        client_phone: appointment.client.clientPhone,
+      },
+      barber: {
+        barber_id: appointment.barber.barberId,
+        barber_name: appointment.barber.barberName,
+      },
+      services: appointment.appointmentServices.map((as) => ({
+        service_id: as.serviceId,
+        service_name: as.service.serviceName,
+        service_price: Number(as.servicePrice).toFixed(2),
+        service_duration: as.serviceDuration,
+      })),
+    })),
+  );
+}

--- a/src/pages/api/v1/barbers/index.js
+++ b/src/pages/api/v1/barbers/index.js
@@ -1,0 +1,48 @@
+import { createRouter } from "next-connect";
+
+import controller from "@/infra/controller";
+import { prisma as db } from "@/infra/prisma.js";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const barbers = await db.barber.findMany({
+    where: {
+      isActive: true,
+    },
+    select: {
+      barberId: true,
+      barberName: true,
+      phoneNumber: true,
+      workStart: true,
+      workEnd: true,
+      lunchStart: true,
+      lunchEnd: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
+
+  return response.status(200).json(
+    barbers.map((barber) => ({
+      barber_id: barber.barberId,
+      barber_name: barber.barberName,
+      phone_number: barber.phoneNumber,
+      work_start: barber.workStart,
+      work_end: barber.workEnd,
+      lunch_start: barber.lunchStart,
+      lunch_end: barber.lunchEnd,
+      is_active: barber.isActive,
+      created_at: barber.createdAt.toISOString(),
+      updated_at: barber.updatedAt.toISOString(),
+    })),
+  );
+}

--- a/src/pages/api/v1/services/index.js
+++ b/src/pages/api/v1/services/index.js
@@ -1,0 +1,44 @@
+import { createRouter } from "next-connect";
+
+import controller from "@/infra/controller";
+import { prisma as db } from "@/infra/prisma.js";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const services = await db.service.findMany({
+    where: {
+      isActive: true,
+    },
+    select: {
+      serviceId: true,
+      serviceName: true,
+      serviceDescription: true,
+      duration: true,
+      price: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
+
+  return response.status(200).json(
+    services.map((service) => ({
+      service_id: service.serviceId,
+      service_name: service.serviceName,
+      service_description: service.serviceDescription,
+      duration: service.duration,
+      price: Number(service.price).toFixed(2),
+      is_active: service.isActive,
+      created_at: service.createdAt.toISOString(),
+      updated_at: service.updatedAt.toISOString(),
+    })),
+  );
+}

--- a/src/pages/api/v1/user/index.js
+++ b/src/pages/api/v1/user/index.js
@@ -1,8 +1,7 @@
 import { createRouter } from "next-connect";
 
+import authentication from "@/infra/authentication";
 import controller from "@/infra/controller";
-import { NotFoundError, UnauthorizedError } from "@/infra/errors";
-import { prisma as db } from "@/infra/prisma.js";
 import session from "@/infra/session.js";
 
 const router = createRouter();
@@ -19,51 +18,12 @@ async function getHandler(request, response) {
   response.setHeader("Pragma", "no-cache");
   response.setHeader("Expires", "0");
 
-  const rawSessionToken = request.cookies.session_id;
-
-  if (!rawSessionToken) {
-    throw new UnauthorizedError({
-      message: "User not authenticated.",
-      action: "Login to access this resource.",
-    });
-  }
-
-  const validSessionObject =
-    await session.findValidSessionbyToken(rawSessionToken);
-
-  if (!validSessionObject) {
-    throw new UnauthorizedError({
-      message: "Invalid or expired session.",
-      action: "Login to continue.",
-    });
-  }
-
-  const userFound = await db.user.findUnique({
-    where: {
-      userId: validSessionObject.userId,
-    },
-    select: {
-      userId: true,
-      username: true,
-      email: true,
-      accessLevel: true,
-      linkedBarberId: true,
-      isActive: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-  });
-
-  if (!userFound) {
-    throw new NotFoundError({
-      message: "User linked to this session was not found.",
-      action: "Login again or contact support.",
-    });
-  }
+  const { user: userFound, session: validSessionObject } =
+    await authentication.getAuthenticatedUserFromRequest(request);
 
   const { sessionCookie } = await session.renew(
     validSessionObject.sessionId,
-    rawSessionToken,
+    request.cookies.session_id,
   );
 
   response.setHeader("Set-Cookie", sessionCookie);

--- a/src/tests/integration/api/v1/appointments/get.test.js
+++ b/src/tests/integration/api/v1/appointments/get.test.js
@@ -1,0 +1,296 @@
+import crypto from "node:crypto";
+
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+import session from "@/infra/session.js";
+
+describe("GET /api/v1/appointments", () => {
+  describe("Anonymous user", () => {
+    test("Without session returns 401", async () => {
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`);
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("UnauthorizedError");
+      expect(responseBody.status_code).toBe(401);
+    });
+
+    test("With nonexistent session returns 401", async () => {
+      const nonexistentToken = crypto.randomBytes(48).toString("hex");
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        headers: {
+          Cookie: `session_id=${nonexistentToken}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("UnauthorizedError");
+    });
+
+    test("With expired session returns 401", async () => {
+      jest.useFakeTimers({
+        now: new Date(
+          Date.now() - session.SESSION_DURATION_IN_MILLISECONDS - 1000,
+        ),
+      });
+
+      const createdUser = await orchestrator.createUser();
+      const sessionObject = await orchestrator.createSession(
+        createdUser.userId,
+      );
+
+      jest.useRealTimers();
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("UnauthorizedError");
+    });
+  });
+
+  describe("Admin user", () => {
+    test("Sees all appointments", async () => {
+      const admin = await orchestrator.createUser({
+        accessLevel: "admin",
+      });
+
+      const adminSession = await orchestrator.createSession(admin.userId);
+
+      const barber1 = await orchestrator.createBarber({
+        barberName: "Barber 1",
+      });
+
+      const barber2 = await orchestrator.createBarber({
+        barberName: "Barber 2",
+      });
+
+      const client1 = await orchestrator.createClient({
+        clientName: "Client 1",
+      });
+
+      const client2 = await orchestrator.createClient({
+        clientName: "Client 2",
+      });
+
+      const now = new Date();
+
+      const appointment1DateTime = new Date(
+        now.getTime() + 24 * 60 * 60 * 1000,
+      );
+      const appointment1EndDateTime = new Date(
+        appointment1DateTime.getTime() + 30 * 60 * 1000,
+      );
+
+      const appointment2DateTime = new Date(
+        now.getTime() + 48 * 60 * 60 * 1000,
+      );
+      const appointment2EndDateTime = new Date(
+        appointment2DateTime.getTime() + 30 * 60 * 1000,
+      );
+
+      const appt1 = await orchestrator.createAppointment({
+        barberId: barber1.barberId,
+        clientId: client1.clientId,
+        appointmentDatetime: appointment1DateTime,
+        appointmentEndDatetime: appointment1EndDateTime,
+        totalDuration: 30,
+      });
+
+      const appt2 = await orchestrator.createAppointment({
+        barberId: barber2.barberId,
+        clientId: client2.clientId,
+        appointmentDatetime: appointment2DateTime,
+        appointmentEndDatetime: appointment2EndDateTime,
+        totalDuration: 30,
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        headers: {
+          Cookie: `session_id=${adminSession.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      const returnedAppointmentIds = responseBody.map(
+        (appointment) => appointment.appointment_id,
+      );
+
+      expect(returnedAppointmentIds).toContain(appt1.appointmentId);
+      expect(returnedAppointmentIds).toContain(appt2.appointmentId);
+
+      const returnedAppt1 = responseBody.find(
+        (appointment) => appointment.appointment_id === appt1.appointmentId,
+      );
+
+      const returnedAppt2 = responseBody.find(
+        (appointment) => appointment.appointment_id === appt2.appointmentId,
+      );
+
+      expect(returnedAppt1).toEqual(
+        expect.objectContaining({
+          appointment_id: appt1.appointmentId,
+          total_duration: 30,
+          status: "AGENDADO",
+          barber: expect.objectContaining({
+            barber_id: barber1.barberId,
+            barber_name: "Barber 1",
+          }),
+          client: expect.objectContaining({
+            client_id: client1.clientId,
+            client_name: "Client 1",
+          }),
+        }),
+      );
+
+      expect(returnedAppt2).toEqual(
+        expect.objectContaining({
+          appointment_id: appt2.appointmentId,
+          total_duration: 30,
+          status: "AGENDADO",
+          barber: expect.objectContaining({
+            barber_id: barber2.barberId,
+            barber_name: "Barber 2",
+          }),
+          client: expect.objectContaining({
+            client_id: client2.clientId,
+            client_name: "Client 2",
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("Barber user", () => {
+    test("Sees only own appointments", async () => {
+      const user1 = await orchestrator.createUser({
+        accessLevel: "barber",
+      });
+
+      const user2 = await orchestrator.createUser({
+        accessLevel: "barber",
+      });
+
+      const barber1 = await orchestrator.createBarber({
+        barberName: "Barber 1",
+      });
+
+      const barber2 = await orchestrator.createBarber({
+        barberName: "Barber 2",
+      });
+
+      await orchestrator.linkUserToBarber(user1.userId, barber1.barberId);
+      await orchestrator.linkUserToBarber(user2.userId, barber2.barberId);
+
+      const client1 = await orchestrator.createClient({
+        clientName: "Client 1",
+      });
+
+      const client2 = await orchestrator.createClient({
+        clientName: "Client 2",
+      });
+
+      const now = new Date();
+
+      const appt1DateTime = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+      const appt1EndDateTime = new Date(
+        appt1DateTime.getTime() + 30 * 60 * 1000,
+      );
+
+      const appt2DateTime = new Date(now.getTime() + 48 * 60 * 60 * 1000);
+      const appt2EndDateTime = new Date(
+        appt2DateTime.getTime() + 30 * 60 * 1000,
+      );
+
+      const appt1 = await orchestrator.createAppointment({
+        barberId: barber1.barberId,
+        clientId: client1.clientId,
+        appointmentDatetime: appt1DateTime,
+        appointmentEndDatetime: appt1EndDateTime,
+        totalDuration: 30,
+      });
+
+      const appt2 = await orchestrator.createAppointment({
+        barberId: barber2.barberId,
+        clientId: client2.clientId,
+        appointmentDatetime: appt2DateTime,
+        appointmentEndDatetime: appt2EndDateTime,
+        totalDuration: 30,
+      });
+
+      const user1Session = await orchestrator.createSession(user1.userId);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        headers: {
+          Cookie: `session_id=${user1Session.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      const returnedAppointmentIds = responseBody.map(
+        (appointment) => appointment.appointment_id,
+      );
+
+      expect(returnedAppointmentIds).toContain(appt1.appointmentId);
+      expect(returnedAppointmentIds).not.toContain(appt2.appointmentId);
+
+      const returnedAppt1 = responseBody.find(
+        (appointment) => appointment.appointment_id === appt1.appointmentId,
+      );
+
+      expect(returnedAppt1).toEqual(
+        expect.objectContaining({
+          appointment_id: appt1.appointmentId,
+          barber: expect.objectContaining({
+            barber_id: barber1.barberId,
+            barber_name: "Barber 1",
+          }),
+          client: expect.objectContaining({
+            client_id: client1.clientId,
+            client_name: "Client 1",
+          }),
+        }),
+      );
+    });
+
+    test("Without linkedBarberId returns 403", async () => {
+      const barberUser = await orchestrator.createUser({
+        accessLevel: "barber",
+        linkedBarberId: null,
+      });
+
+      const barberSession = await orchestrator.createSession(barberUser.userId);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        headers: {
+          Cookie: `session_id=${barberSession.token}`,
+        },
+      });
+
+      expect(response.status).toBe(403);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ForbiddenError");
+      expect(responseBody.status_code).toBe(403);
+    });
+  });
+});

--- a/src/tests/integration/api/v1/appointments/post.test.js
+++ b/src/tests/integration/api/v1/appointments/post.test.js
@@ -1,0 +1,429 @@
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+
+describe("POST /api/v1/appointments", () => {
+  describe("Anonymous user", () => {
+    test("Creates appointment with one service", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "John",
+      });
+
+      const service = await orchestrator.createService({
+        serviceName: "Haircut",
+        duration: 30,
+        price: 50,
+      });
+
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000); // Tomorrow
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [service.serviceId],
+          client_name: "John Doe",
+          client_phone: "123456789",
+        }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.appointment_id).toBeTruthy();
+      expect(responseBody.barber_id).toBe(barber.barberId);
+      expect(responseBody.total_duration).toBe(30);
+      expect(responseBody.status).toBe("AGENDADO");
+      expect(responseBody.services).toHaveLength(1);
+      expect(responseBody.services[0]).toEqual({
+        service_id: service.serviceId,
+        service_name: "Haircut",
+        service_price: "50.00",
+        service_duration: 30,
+      });
+
+      const expectedEndDateTime = new Date(
+        appointmentDateTime.getTime() + 30 * 60 * 1000,
+      );
+      expect(new Date(responseBody.appointment_end_datetime).getTime()).toBe(
+        expectedEndDateTime.getTime(),
+      );
+    });
+
+    test("Creates appointment with multiple services", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "John",
+      });
+
+      const service1 = await orchestrator.createService({
+        serviceName: "Haircut",
+        duration: 30,
+        price: 50,
+      });
+
+      const service2 = await orchestrator.createService({
+        serviceName: "Beard Trim",
+        duration: 20,
+        price: 30,
+      });
+
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [service1.serviceId, service2.serviceId],
+          client_name: "Jane Doe",
+        }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.total_duration).toBe(50); // 30 + 20
+      expect(responseBody.services).toHaveLength(2);
+
+      const expectedEndDateTime = new Date(
+        appointmentDateTime.getTime() + 50 * 60 * 1000,
+      );
+      expect(new Date(responseBody.appointment_end_datetime).getTime()).toBe(
+        expectedEndDateTime.getTime(),
+      );
+    });
+
+    test("Missing barber_id returns 400", async () => {
+      const service = await orchestrator.createService();
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [service.serviceId],
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("barber_id");
+    });
+
+    test("Missing appointment_datetime returns 400", async () => {
+      const barber = await orchestrator.createBarber();
+      const service = await orchestrator.createService();
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          service_ids: [service.serviceId],
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("appointment_datetime");
+    });
+
+    test("Missing service_ids returns 400", async () => {
+      const barber = await orchestrator.createBarber();
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("service_ids");
+    });
+
+    test("Empty service_ids returns 400", async () => {
+      const barber = await orchestrator.createBarber();
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [],
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("non-empty");
+    });
+
+    test("Missing client_name returns 400", async () => {
+      const barber = await orchestrator.createBarber();
+      const service = await orchestrator.createService();
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [service.serviceId],
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("client_name");
+    });
+
+    test("Nonexistent barber returns 404", async () => {
+      const service = await orchestrator.createService();
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      const fakeUuid = "123e4567-e89b-12d3-a456-426614174000";
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: fakeUuid,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [service.serviceId],
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("NotFoundError");
+      expect(responseBody.message).toContain("Barber");
+    });
+
+    test("Inactive barber returns 400", async () => {
+      const barber = await orchestrator.createBarber({
+        isActive: false,
+      });
+
+      const service = await orchestrator.createService();
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [service.serviceId],
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("not active");
+    });
+
+    test("Nonexistent service returns 404", async () => {
+      const barber = await orchestrator.createBarber();
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      const fakeUuid = "123e4567-e89b-12d3-a456-426614174000";
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [fakeUuid],
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("NotFoundError");
+      expect(responseBody.message).toContain("services not found");
+    });
+
+    test("Inactive service returns 400", async () => {
+      const barber = await orchestrator.createBarber();
+      const service = await orchestrator.createService({
+        isActive: false,
+      });
+
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [service.serviceId],
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("not active");
+    });
+
+    test("Duplicate appointment time returns 400", async () => {
+      const barber = await orchestrator.createBarber();
+      const service = await orchestrator.createService();
+      const client = await orchestrator.createClient();
+
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      // Create first appointment
+      await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: appointmentDateTime,
+        appointmentEndDatetime: new Date(
+          appointmentDateTime.getTime() + 30 * 60 * 1000,
+        ),
+        totalDuration: 30,
+        status: "AGENDADO",
+      });
+
+      // Try to create second appointment at same time
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [service.serviceId],
+          client_name: "Jane Doe",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("already exists");
+    });
+
+    test("Duplicate service IDs returns 400", async () => {
+      const barber = await orchestrator.createBarber();
+      const service = await orchestrator.createService();
+      const appointmentDateTime = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: appointmentDateTime.toISOString(),
+          service_ids: [service.serviceId, service.serviceId],
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("Duplicate");
+    });
+
+    test("Appointment datetime in the past returns 400", async () => {
+      const barber = await orchestrator.createBarber();
+      const service = await orchestrator.createService();
+      const pastDateTime = new Date(Date.now() - 24 * 60 * 60 * 1000); // Yesterday
+
+      const response = await fetch(`${webserver.origin}/api/v1/appointments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          barber_id: barber.barberId,
+          appointment_datetime: pastDateTime.toISOString(),
+          service_ids: [service.serviceId],
+          client_name: "John Doe",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody.name).toBe("ValidationError");
+      expect(responseBody.message).toContain("past");
+    });
+  });
+});

--- a/src/tests/integration/api/v1/barbers/get.test.js
+++ b/src/tests/integration/api/v1/barbers/get.test.js
@@ -1,0 +1,88 @@
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+
+describe("GET /api/v1/barbers", () => {
+  describe("Anonymous user", () => {
+    test("With empty barbers list", async () => {
+      const response = await fetch(`${webserver.origin}/api/v1/barbers`);
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(Array.isArray(responseBody)).toBe(true);
+    });
+
+    test("With active barbers", async () => {
+      const createdBarber1 = await orchestrator.createBarber({
+        barberName: "Barber 1",
+        phoneNumber: "123456789",
+        workStart: "08:00",
+        workEnd: "18:00",
+      });
+
+      const createdBarber2 = await orchestrator.createBarber({
+        barberName: "Barber 2",
+        phoneNumber: "987654321",
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/barbers`);
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            barber_id: createdBarber1.barberId,
+            barber_name: "Barber 1",
+            phone_number: "123456789",
+            work_start: "08:00",
+            work_end: "18:00",
+            lunch_start: null,
+            lunch_end: null,
+            is_active: true,
+            created_at: createdBarber1.createdAt.toISOString(),
+            updated_at: createdBarber1.updatedAt.toISOString(),
+          }),
+          expect.objectContaining({
+            barber_id: createdBarber2.barberId,
+            barber_name: "Barber 2",
+            phone_number: "987654321",
+            work_start: "08:00",
+            work_end: "18:00",
+            lunch_start: null,
+            lunch_end: null,
+            is_active: true,
+            created_at: createdBarber2.createdAt.toISOString(),
+            updated_at: createdBarber2.updatedAt.toISOString(),
+          }),
+        ]),
+      );
+    });
+
+    test("With inactive barbers excluded", async () => {
+      await orchestrator.createBarber({
+        barberName: "Active Barber",
+        isActive: true,
+      });
+
+      await orchestrator.createBarber({
+        barberName: "Inactive Barber",
+        isActive: false,
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/barbers`);
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      // Ensure active barber is present and inactive barber is not
+      const names = responseBody.map((b) => b.barber_name);
+      expect(names).toEqual(expect.arrayContaining(["Active Barber"]));
+      expect(names).not.toEqual(expect.arrayContaining(["Inactive Barber"]));
+    });
+  });
+});

--- a/src/tests/integration/api/v1/services/get.test.js
+++ b/src/tests/integration/api/v1/services/get.test.js
@@ -1,0 +1,135 @@
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+
+describe("GET /api/v1/services", () => {
+  describe("Anonymous user", () => {
+    test("With empty services list", async () => {
+      await orchestrator.clearDatabase();
+
+      const response = await fetch(`${webserver.origin}/api/v1/services`);
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual([]);
+    });
+
+    test("With active services", async () => {
+      const createdService1 = await orchestrator.createService({
+        serviceName: "Haircut",
+        serviceDescription: "Basic haircut",
+        duration: 30,
+        price: 50,
+      });
+
+      const createdService2 = await orchestrator.createService({
+        serviceName: "Beard Trim",
+        serviceDescription: "Professional beard trim",
+        duration: 20,
+        price: 30,
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/services`);
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      const returnedServiceIds = responseBody.map(
+        (service) => service.service_id,
+      );
+
+      expect(returnedServiceIds).toContain(createdService1.serviceId);
+      expect(returnedServiceIds).toContain(createdService2.serviceId);
+
+      const returnedService1 = responseBody.find(
+        (service) => service.service_id === createdService1.serviceId,
+      );
+
+      const returnedService2 = responseBody.find(
+        (service) => service.service_id === createdService2.serviceId,
+      );
+
+      expect(returnedService1).toEqual({
+        service_id: createdService1.serviceId,
+        service_name: "Haircut",
+        service_description: "Basic haircut",
+        duration: 30,
+        price: "50.00",
+        is_active: true,
+        created_at: createdService1.createdAt.toISOString(),
+        updated_at: createdService1.updatedAt.toISOString(),
+      });
+
+      expect(returnedService2).toEqual({
+        service_id: createdService2.serviceId,
+        service_name: "Beard Trim",
+        service_description: "Professional beard trim",
+        duration: 20,
+        price: "30.00",
+        is_active: true,
+        created_at: createdService2.createdAt.toISOString(),
+        updated_at: createdService2.updatedAt.toISOString(),
+      });
+    });
+
+    test("With inactive services excluded", async () => {
+      const activeService = await orchestrator.createService({
+        serviceName: "Active Service",
+        isActive: true,
+      });
+
+      const inactiveService = await orchestrator.createService({
+        serviceName: "Inactive Service",
+        isActive: false,
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/services`);
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      const returnedServiceIds = responseBody.map(
+        (service) => service.service_id,
+      );
+
+      expect(returnedServiceIds).toContain(activeService.serviceId);
+      expect(returnedServiceIds).not.toContain(inactiveService.serviceId);
+
+      const returnedActiveService = responseBody.find(
+        (service) => service.service_id === activeService.serviceId,
+      );
+
+      expect(returnedActiveService).toEqual(
+        expect.objectContaining({
+          service_id: activeService.serviceId,
+          service_name: "Active Service",
+          is_active: true,
+        }),
+      );
+    });
+
+    test("Price is serialized as string", async () => {
+      const createdService = await orchestrator.createService({
+        serviceName: "Premium Service",
+        price: 99.99,
+      });
+
+      const response = await fetch(`${webserver.origin}/api/v1/services`);
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      const returnedService = responseBody.find(
+        (service) => service.service_id === createdService.serviceId,
+      );
+
+      expect(returnedService).toBeDefined();
+      expect(returnedService.price).toBe("99.99");
+      expect(typeof returnedService.price).toBe("string");
+    });
+  });
+});

--- a/src/tests/orchestrator/orchestrator.mjs
+++ b/src/tests/orchestrator/orchestrator.mjs
@@ -142,11 +142,73 @@ async function createSession(userId) {
   };
 }
 
+async function createBarber(barberObject = {}) {
+  return await db.barber.create({
+    data: {
+      barberName: barberObject.barberName || faker.person.fullName(),
+      phoneNumber: barberObject.phoneNumber || null,
+      workStart: barberObject.workStart || "08:00",
+      workEnd: barberObject.workEnd || "18:00",
+      lunchStart: barberObject.lunchStart || null,
+      lunchEnd: barberObject.lunchEnd || null,
+      isActive: barberObject.isActive ?? true,
+    },
+  });
+}
+
+async function createService(serviceObject = {}) {
+  return await db.service.create({
+    data: {
+      serviceName: serviceObject.serviceName || faker.commerce.productName(),
+      serviceDescription: serviceObject.serviceDescription || null,
+      duration: serviceObject.duration || 30,
+      price: serviceObject.price || 50,
+      isActive: serviceObject.isActive ?? true,
+    },
+  });
+}
+
+async function createClient(clientObject = {}) {
+  return await db.client.create({
+    data: {
+      clientName: clientObject.clientName || faker.person.fullName(),
+      clientPhone: clientObject.clientPhone || null,
+      isActive: clientObject.isActive ?? true,
+    },
+  });
+}
+
+async function createAppointment(appointmentObject = {}) {
+  return await db.appointment.create({
+    data: {
+      appointmentDatetime: appointmentObject.appointmentDatetime || new Date(),
+      appointmentEndDatetime:
+        appointmentObject.appointmentEndDatetime || new Date(),
+      totalDuration: appointmentObject.totalDuration || 0,
+      status: appointmentObject.status || "AGENDADO",
+      clientId: appointmentObject.clientId,
+      barberId: appointmentObject.barberId,
+    },
+  });
+}
+
+async function linkUserToBarber(userId, barberId) {
+  return await db.user.update({
+    where: { userId },
+    data: { linkedBarberId: barberId },
+  });
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
   createUser,
   createSession,
+  createBarber,
+  createService,
+  createClient,
+  createAppointment,
+  linkUserToBarber,
 };
 
 export default orchestrator;


### PR DESCRIPTION
## Summary

This PR expands the API authorization infrastructure and introduces the first scheduling-related endpoints for the barbershop system.

It centralizes authenticated user resolution, adds reusable authorization helpers, and implements protected endpoints for appointments, barbers, and services.

The PR also adds integration coverage for the new endpoints and introduces supporting authorization documentation.

## Main changes

### Authorization infrastructure

- Added reusable authorization layer
  - Centralized authenticated user/session resolution
  - Reduced duplication across protected endpoints
  - Added request-based authentication helpers

- Refactored `/api/v1/user`
  - Uses shared authentication infrastructure
  - Simplified protected route logic
  - Preserved session renewal behavior

### Scheduling API endpoints

- Added `/api/v1/appointments`
  - Appointment retrieval and management endpoints
  - Authorization-aware access behavior

- Added `/api/v1/barbers`
  - Barber listing and management endpoints

- Added `/api/v1/services`
  - Service listing and management endpoints

### Test infrastructure

- Expanded orchestrator helpers
  - Added reusable factories for:
    - barbers
    - services
    - clients
    - appointments
    - barber-user linking

- Added integration tests for:
  - appointments endpoints
  - barbers endpoints
  - services endpoints
  - authorization-related flows

### Documentation

- Added authorization implementation guide documenting
  the current authorization architecture and request flow.

## Notes

This PR continues the transition from isolated endpoint-specific
authentication logic to a centralized authorization model designed
to support future role-based access control and scheduling workflows.