### PR TITLE
fix: allow rebooking cancelled appointment slots with partial unique index

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "db:seed:admin": "node src/scripts/seed-admin.mjs",
     "db:seed:admin:dev": "dotenv -e .env.development -- npm run db:seed:admin",
     "db:seed:admin:test": "dotenv -e .env.test -- npm run db:seed:admin",
-    "db:seed:admin:prod": "dotenv -e .env.production -- npm run db:seed:admin"
+    "db:seed:admin:prod": "dotenv -e .env.production -- npm run db:seed:admin",
+    "db:reset:development": "dotenv -e .env.development -- prisma migrate reset --force",
+    "db:reset:test": "dotenv -e .env.test -- prisma migrate reset --force"
   },
   "author": "",
   "license": "MIT",

--- a/prisma/migrations/20260529143000_add_partial_unique_index_for_active_appointments/migration.sql
+++ b/prisma/migrations/20260529143000_add_partial_unique_index_for_active_appointments/migration.sql
@@ -1,0 +1,36 @@
+-- This migration replaces the broad unique constraint on
+-- (barber_id, appointment_datetime) with a PostgreSQL partial unique index.
+--
+-- Old behavior:
+-- A barber could not have another appointment at the same datetime,
+-- even if the previous appointment was CANCELADO, CONCLUIDO, or FALTOU.
+--
+-- New behavior:
+-- A barber cannot have two appointments at the same datetime only when
+-- the appointment is still AGENDADO.
+-- 1. Remove the old Prisma-generated uniqueness rule.
+-- Depending on the exact migration history, PostgreSQL may store it as a
+-- constraint and/or an index. These defensive statements are safe for your
+-- current phase because you said the databases can be reset.
+ALTER TABLE "appointments"
+DROP CONSTRAINT IF EXISTS "uqBarberDatetime";
+
+ALTER TABLE "appointments"
+DROP CONSTRAINT IF EXISTS "appointments_barber_id_appointment_datetime_key";
+
+DROP INDEX IF EXISTS "uqBarberDatetime";
+
+DROP INDEX IF EXISTS "appointments_barber_id_appointment_datetime_key";
+
+-- 2. Create a normal non-unique index for lookup performance.
+-- This matches the new Prisma schema:
+-- @@index([barberId, appointmentDatetime], name: "idxAppointmentsBarberDatetime")
+CREATE INDEX IF NOT EXISTS "idxAppointmentsBarberDatetime" ON "appointments" ("barber_id", "appointment_datetime");
+
+-- 3. Create the real database-level business rule.
+-- Only AGENDADO appointments block the barber/time slot.
+-- CANCELADO, CONCLUIDO, and FALTOU remain visible as history,
+-- but they no longer prevent a new appointment at the same datetime.
+CREATE UNIQUE INDEX IF NOT EXISTS "appointments_barber_datetime_active_unique" ON "appointments" ("barber_id", "appointment_datetime")
+WHERE
+  "status" = 'AGENDADO';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,9 +122,20 @@ model Appointment {
 
   appointmentServices AppointmentService[]
 
-  @@unique([barberId, appointmentDatetime], name: "uqBarberDatetime")
+  // PostgreSQL-only partial unique index managed manually in migrations:
+  //
+  // CREATE UNIQUE INDEX "appointments_barber_datetime_active_unique"
+  // ON "appointments" ("barber_id", "appointment_datetime")
+  // WHERE "status" = 'AGENDADO';
+  //
+  // Reason:
+  // Prisma does not model partial unique indexes directly in schema.prisma.
+  // This index allows cancelled/concluded/no-show appointments to remain as history
+  // without blocking the same barber/time slot from being booked again.
+
   @@index([clientId], name: "idxAppointmentsClient")
   @@index([appointmentDatetime], name: "idxAppointmentsDatetime")
+  @@index([barberId, appointmentDatetime], name: "idxAppointmentsBarberDatetime")
   @@index([barberId, status, appointmentDatetime], name: "idxAppointmentsBarberStatusDatetime")
   @@index([barberId, status, appointmentDatetime, appointmentEndDatetime], name: "idxAppointmentsBarberStatusRange")
   @@map("appointments")


### PR DESCRIPTION
## Summary

Replaces the broad appointment uniqueness constraint with a PostgreSQL partial unique index that only applies to scheduled appointments (`AGENDADO`).

This allows cancelled appointments to remain in the database as historical records while freeing the corresponding time slot for future bookings.

## Problem

The previous constraint:

```prisma
@@unique([barberId, appointmentDatetime], name: "uqBarberDatetime")