### PR TITLE
feat(admin): add soft delete for services and barbers

### DIFF
--- a/src/pages/api/v1/barbers/[barber_id]/index.js
+++ b/src/pages/api/v1/barbers/[barber_id]/index.js
@@ -1,0 +1,154 @@
+import { createRouter } from "next-connect";
+
+import controller from "@/infra/controller";
+import { prisma as db } from "@/infra/prisma.js";
+
+import { NotFoundError, ValidationError } from "@/infra/errors";
+import authentication from "@/infra/authentication.js";
+import authorization from "@/infra/authorization.js";
+
+const router = createRouter();
+
+router.delete(deleteHandler);
+
+export default router.handler(controller.errorHandlers);
+
+// ---------------------------------------------------------------------------
+// Select block
+// ---------------------------------------------------------------------------
+
+const barberSelect = {
+  barberId: true,
+  barberName: true,
+  phoneNumber: true,
+  workStart: true,
+  workEnd: true,
+  lunchStart: true,
+  lunchEnd: true,
+  isActive: true,
+  createdAt: true,
+  updatedAt: true,
+};
+
+// ---------------------------------------------------------------------------
+// Response mapper
+// ---------------------------------------------------------------------------
+
+function mapBarberResponse(barber) {
+  return {
+    barber_id: barber.barberId,
+    barber_name: barber.barberName,
+    phone_number: barber.phoneNumber,
+    work_start: barber.workStart,
+    work_end: barber.workEnd,
+    lunch_start: barber.lunchStart,
+    lunch_end: barber.lunchEnd,
+    is_active: barber.isActive,
+    created_at: barber.createdAt.toISOString(),
+    updated_at: barber.updatedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+async function deleteHandler(request, response) {
+  const { user } =
+    await authentication.getAuthenticatedUserFromRequest(request);
+  authorization.ensureAdmin(user);
+
+  const barberId = extractBarberId(request);
+
+  const barber = await db.barber.findUnique({
+    where: { barberId },
+    select: {
+      ...barberSelect,
+      user: {
+        select: { userId: true },
+      },
+    },
+  });
+
+  if (!barber) {
+    throw new NotFoundError({
+      message: "Barber not found.",
+      action: "Verify if the barber_id is correct.",
+    });
+  }
+
+  // Idempotent: already inactive — return current data without writing
+  if (!barber.isActive) {
+    return response.status(200).json({
+      barber: mapBarberResponse(barber),
+      cancelled_appointments_count: 0,
+    });
+  }
+
+  const { updatedBarber, cancelledCount } = await db.$transaction(
+    async (tx) => {
+      // Step 1: Deactivate barber
+      const updated = await tx.barber.update({
+        where: { barberId },
+        data: { isActive: false },
+        select: barberSelect,
+      });
+
+      // Step 2: Deactivate linked user (if exists)
+      if (barber.user) {
+        await tx.user.update({
+          where: { userId: barber.user.userId },
+          data: { isActive: false },
+        });
+      }
+
+      // Step 3: Cancel future AGENDADO appointments
+      const cancelResult = await tx.appointment.updateMany({
+        where: {
+          barberId,
+          status: "AGENDADO",
+          appointmentDatetime: { gte: new Date() },
+        },
+        data: { status: "CANCELADO" },
+      });
+
+      return { updatedBarber: updated, cancelledCount: cancelResult.count };
+    },
+  );
+
+  return response.status(200).json({
+    barber: mapBarberResponse(updatedBarber),
+    cancelled_appointments_count: cancelledCount,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function extractBarberId(request) {
+  const rawBarberId = request.query.barber_id;
+  const barberId = Array.isArray(rawBarberId) ? rawBarberId[0] : rawBarberId;
+
+  if (!barberId) {
+    throw new ValidationError({
+      message: "Missing required parameter: barber_id.",
+      action: "Provide a barber_id in the route.",
+    });
+  }
+
+  if (!isValidUuid(barberId)) {
+    throw new ValidationError({
+      message: "barber_id must be a valid UUID.",
+      action: "Provide a valid barber_id.",
+    });
+  }
+
+  return barberId;
+}
+
+function isValidUuid(value) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}

--- a/src/pages/api/v1/services/[service_id]/index.js
+++ b/src/pages/api/v1/services/[service_id]/index.js
@@ -1,0 +1,116 @@
+import { createRouter } from "next-connect";
+
+import controller from "@/infra/controller";
+import { prisma as db } from "@/infra/prisma.js";
+
+import { NotFoundError, ValidationError } from "@/infra/errors";
+import authentication from "@/infra/authentication.js";
+import authorization from "@/infra/authorization.js";
+
+const router = createRouter();
+
+router.delete(deleteHandler);
+
+export default router.handler(controller.errorHandlers);
+
+// ---------------------------------------------------------------------------
+// Select block
+// ---------------------------------------------------------------------------
+
+const serviceSelect = {
+  serviceId: true,
+  serviceName: true,
+  serviceDescription: true,
+  duration: true,
+  price: true,
+  isActive: true,
+  createdAt: true,
+  updatedAt: true,
+};
+
+// ---------------------------------------------------------------------------
+// Response mapper
+// ---------------------------------------------------------------------------
+
+function mapServiceResponse(service) {
+  return {
+    service_id: service.serviceId,
+    service_name: service.serviceName,
+    service_description: service.serviceDescription,
+    duration: service.duration,
+    price: Number(service.price).toFixed(2),
+    is_active: service.isActive,
+    created_at: service.createdAt.toISOString(),
+    updated_at: service.updatedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+async function deleteHandler(request, response) {
+  const { user } =
+    await authentication.getAuthenticatedUserFromRequest(request);
+  authorization.ensureAdmin(user);
+
+  const serviceId = extractServiceId(request);
+
+  const service = await db.service.findUnique({
+    where: { serviceId },
+    select: serviceSelect,
+  });
+
+  if (!service) {
+    throw new NotFoundError({
+      message: "Service not found.",
+      action: "Verify if the service_id is correct.",
+    });
+  }
+
+  // Idempotent: already inactive — return current data without writing
+  if (!service.isActive) {
+    return response.status(200).json(mapServiceResponse(service));
+  }
+
+  const updatedService = await db.service.update({
+    where: { serviceId },
+    data: { isActive: false },
+    select: serviceSelect,
+  });
+
+  return response.status(200).json(mapServiceResponse(updatedService));
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function extractServiceId(request) {
+  const rawServiceId = request.query.service_id;
+  const serviceId = Array.isArray(rawServiceId)
+    ? rawServiceId[0]
+    : rawServiceId;
+
+  if (!serviceId) {
+    throw new ValidationError({
+      message: "Missing required parameter: service_id.",
+      action: "Provide a service_id in the route.",
+    });
+  }
+
+  if (!isValidUuid(serviceId)) {
+    throw new ValidationError({
+      message: "service_id must be a valid UUID.",
+      action: "Provide a valid service_id.",
+    });
+  }
+
+  return serviceId;
+}
+
+function isValidUuid(value) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}

--- a/src/pages/dashboard/employees.jsx
+++ b/src/pages/dashboard/employees.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import LoadingDialog from "@/components/ui/LoadingDialog";
 import {
@@ -592,6 +593,11 @@ export default function DashboardEmployeesPage() {
   const [fetchError, setFetchError] = useState(null);
   const [selectedBarberToEdit, setSelectedBarberToEdit] = useState(null);
 
+  // Delete flow state
+  const [barberToDelete, setBarberToDelete] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
+
   useEffect(() => {
     async function fetchBarbers() {
       setLoadingFetch(true);
@@ -632,10 +638,39 @@ export default function DashboardEmployeesPage() {
     // - Update the local barbers list
   }
 
-  function handleBarberDeleted(barberId) {
-    setBarbers((prev) => {
-      return prev.filter((barber) => barber.barber_id !== barberId);
-    });
+  function handleBarberDeleteRequest(barberId) {
+    setDeleteError(null);
+    setBarberToDelete(barberId);
+  }
+
+  function handleDeleteCancel() {
+    setBarberToDelete(null);
+  }
+
+  async function handleDeleteConfirm() {
+    const barberId = barberToDelete;
+    setBarberToDelete(null);
+    setDeleting(true);
+    setDeleteError(null);
+
+    try {
+      const res = await fetch(`/api/v1/barbers/${barberId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message || "Erro ao excluir barbeiro.");
+      }
+
+      setBarbers((prev) =>
+        prev.filter((barber) => barber.barber_id !== barberId),
+      );
+    } catch (err) {
+      setDeleteError(err.message);
+    } finally {
+      setDeleting(false);
+    }
   }
 
   return (
@@ -758,13 +793,45 @@ export default function DashboardEmployeesPage() {
                   key={barber.barber_id}
                   barber={barber}
                   onEdit={handleBarberEdit}
-                  onDelete={handleBarberDeleted}
+                  onDelete={handleBarberDeleteRequest}
                 />
               ))}
             </div>
           )}
         </div>
       </div>
+      {/* Delete error banner */}
+      {deleteError && (
+        <div
+          role="alert"
+          className="mx-8 mb-12 bg-red-950/40 border-l-4 border-red-500/60 px-6 py-5"
+        >
+          <p className="text-xs font-label uppercase tracking-widest text-red-400 mb-1">
+            Erro ao excluir
+          </p>
+
+          <p className="text-sm text-red-300 leading-relaxed">
+            {deleteError}
+          </p>
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={barberToDelete !== null}
+        title="Excluir barbeiro?"
+        description="Este barbeiro será removido da lista de profissionais ativos. Agendamentos futuros vinculados a ele serão cancelados."
+        confirmLabel="Sim, excluir barbeiro"
+        cancelLabel="Cancelar"
+        variant="danger"
+        onConfirm={handleDeleteConfirm}
+        onCancel={handleDeleteCancel}
+      />
+
+      <LoadingDialog
+        isOpen={deleting}
+        title="Excluindo barbeiro"
+        description="Estamos removendo o barbeiro e cancelando agendamentos futuros. Isso levará apenas um momento."
+      />
     </>
   );
 }

--- a/src/pages/dashboard/employees.jsx
+++ b/src/pages/dashboard/employees.jsx
@@ -810,9 +810,7 @@ export default function DashboardEmployeesPage() {
             Erro ao excluir
           </p>
 
-          <p className="text-sm text-red-300 leading-relaxed">
-            {deleteError}
-          </p>
+          <p className="text-sm text-red-300 leading-relaxed">{deleteError}</p>
         </div>
       )}
 

--- a/src/pages/dashboard/services.jsx
+++ b/src/pages/dashboard/services.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import LoadingDialog from "@/components/ui/LoadingDialog";
 import pageAuthorization from "@/infra/pageAuthorization";
@@ -385,6 +386,11 @@ export default function DashboardServicesPage() {
   const [fetchError, setFetchError] = useState(null);
   const [selectedServiceToEdit, setSelectedServiceToEdit] = useState(null);
 
+  // Delete flow state
+  const [serviceToDelete, setServiceToDelete] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
+
   useEffect(() => {
     async function fetchServices() {
       setLoadingFetch(true);
@@ -425,10 +431,39 @@ export default function DashboardServicesPage() {
     // - Update the local services list
   }
 
-  function handleServiceDeleted(serviceId) {
-    setServices((prev) => {
-      return prev.filter((service) => service.service_id !== serviceId);
-    });
+  function handleServiceDeleteRequest(serviceId) {
+    setDeleteError(null);
+    setServiceToDelete(serviceId);
+  }
+
+  function handleDeleteCancel() {
+    setServiceToDelete(null);
+  }
+
+  async function handleDeleteConfirm() {
+    const serviceId = serviceToDelete;
+    setServiceToDelete(null);
+    setDeleting(true);
+    setDeleteError(null);
+
+    try {
+      const res = await fetch(`/api/v1/services/${serviceId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message || "Erro ao excluir serviço.");
+      }
+
+      setServices((prev) =>
+        prev.filter((service) => service.service_id !== serviceId),
+      );
+    } catch (err) {
+      setDeleteError(err.message);
+    } finally {
+      setDeleting(false);
+    }
   }
 
   return (
@@ -555,13 +590,46 @@ export default function DashboardServicesPage() {
                   key={service.service_id}
                   service={service}
                   onEdit={handleServiceEdit}
-                  onDelete={handleServiceDeleted}
+                  onDelete={handleServiceDeleteRequest}
                 />
               ))}
             </div>
           )}
         </div>
       </div>
+
+      {/* Delete error banner */}
+      {deleteError && (
+        <div
+          role="alert"
+          className="mx-8 mb-12 bg-red-950/40 border-l-4 border-red-500/60 px-6 py-5"
+        >
+          <p className="text-xs font-label uppercase tracking-widest text-red-400 mb-1">
+            Erro ao excluir
+          </p>
+
+          <p className="text-sm text-red-300 leading-relaxed">
+            {deleteError}
+          </p>
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={serviceToDelete !== null}
+        title="Excluir serviço?"
+        description="Este serviço será removido da lista de serviços ativos. Agendamentos antigos que usaram este serviço não serão apagados."
+        confirmLabel="Sim, excluir serviço"
+        cancelLabel="Cancelar"
+        variant="danger"
+        onConfirm={handleDeleteConfirm}
+        onCancel={handleDeleteCancel}
+      />
+
+      <LoadingDialog
+        isOpen={deleting}
+        title="Excluindo serviço"
+        description="Estamos removendo o serviço da lista de serviços ativos. Isso levará apenas um momento."
+      />
     </>
   );
 }

--- a/src/pages/dashboard/services.jsx
+++ b/src/pages/dashboard/services.jsx
@@ -608,9 +608,7 @@ export default function DashboardServicesPage() {
             Erro ao excluir
           </p>
 
-          <p className="text-sm text-red-300 leading-relaxed">
-            {deleteError}
-          </p>
+          <p className="text-sm text-red-300 leading-relaxed">{deleteError}</p>
         </div>
       )}
 

--- a/src/tests/integration/api/v1/barbers/delete.test.js
+++ b/src/tests/integration/api/v1/barbers/delete.test.js
@@ -1,0 +1,505 @@
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+import { prisma as db } from "@/infra/prisma.js";
+
+describe("DELETE /api/v1/barbers/[barber_id]", () => {
+  describe("Anonymous user", () => {
+    test("Cannot delete barber (401)", async () => {
+      await orchestrator.clearDatabase();
+
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber to delete",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+        },
+      );
+
+      expect(response.status).toBe(401);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("UnauthorizedError");
+    });
+  });
+
+  describe("Authenticated Barber user", () => {
+    test("Cannot delete barber (403)", async () => {
+      const barberUser = await orchestrator.createUser({
+        accessLevel: "barber",
+      });
+      const session = await orchestrator.createSession(barberUser.userId);
+
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber forbidden",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${session.token}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(403);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ForbiddenError");
+    });
+  });
+
+  describe("Authenticated Admin user", () => {
+    let adminSessionToken;
+
+    beforeAll(async () => {
+      const adminUser = await orchestrator.createUser({
+        accessLevel: "admin",
+      });
+      const session = await orchestrator.createSession(adminUser.userId);
+      adminSessionToken = session.token;
+    });
+
+    // ── Core soft-delete ──────────────────────────────────────────────────
+
+    test("Can soft-delete an active barber (200)", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber to soft-delete",
+        phoneNumber: "11999999999",
+        workStart: "08:00",
+        workEnd: "18:00",
+        lunchStart: "12:00",
+        lunchEnd: "13:00",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.barber).toEqual(
+        expect.objectContaining({
+          barber_id: barber.barberId,
+          barber_name: "Barber to soft-delete",
+          phone_number: "11999999999",
+          work_start: "08:00",
+          work_end: "18:00",
+          lunch_start: "12:00",
+          lunch_end: "13:00",
+          is_active: false,
+        }),
+      );
+      expect(responseBody.barber.created_at).toBeDefined();
+      expect(responseBody.barber.updated_at).toBeDefined();
+      expect(responseBody.cancelled_appointments_count).toBeDefined();
+    });
+
+    test("Soft-deleted barber no longer appears in GET /api/v1/barbers", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber vanishes from list",
+        isActive: true,
+      });
+
+      const deleteResponse = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(deleteResponse.status).toBe(200);
+
+      const getResponse = await fetch(`${webserver.origin}/api/v1/barbers`);
+      expect(getResponse.status).toBe(200);
+
+      const barbers = await getResponse.json();
+      const barberIds = barbers.map((b) => b.barber_id);
+      expect(barberIds).not.toContain(barber.barberId);
+    });
+
+    test("Barber row still exists in database with isActive = false", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber still in DB",
+        isActive: true,
+      });
+
+      const deleteResponse = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(deleteResponse.status).toBe(200);
+
+      const dbBarber = await db.barber.findUnique({
+        where: { barberId: barber.barberId },
+        select: { barberId: true, barberName: true, isActive: true },
+      });
+
+      expect(dbBarber).not.toBeNull();
+      expect(dbBarber.barberId).toBe(barber.barberId);
+      expect(dbBarber.barberName).toBe("Barber still in DB");
+      expect(dbBarber.isActive).toBe(false);
+    });
+
+    test("Deleting an already inactive barber is idempotent (200)", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Already inactive barber",
+        isActive: false,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.barber).toEqual(
+        expect.objectContaining({
+          barber_id: barber.barberId,
+          barber_name: "Already inactive barber",
+          is_active: false,
+        }),
+      );
+      expect(responseBody.cancelled_appointments_count).toBe(0);
+    });
+
+    test("Nonexistent valid barber_id (404)", async () => {
+      const fakeUuid = "00000000-0000-4000-a000-000000000000";
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${fakeUuid}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(404);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("NotFoundError");
+    });
+
+    test("Invalid barber_id format (400)", async () => {
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/not-a-uuid`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(400);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ValidationError");
+    });
+
+    // ── Linked user ───────────────────────────────────────────────────────
+
+    test("Linked user is also deactivated", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber with linked user",
+      });
+
+      const linkedUser = await orchestrator.createUser({
+        accessLevel: "barber",
+        linkedBarberId: barber.barberId,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const dbUser = await db.user.findUnique({
+        where: { userId: linkedUser.userId },
+        select: { userId: true, isActive: true },
+      });
+
+      expect(dbUser).not.toBeNull();
+      expect(dbUser.isActive).toBe(false);
+    });
+
+    test("Barber deletion succeeds when no linked user exists", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber without user",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+      expect(responseBody.barber.is_active).toBe(false);
+    });
+
+    // ── Appointment cancellation ──────────────────────────────────────────
+
+    test("Future AGENDADO appointments are cancelled", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber with future appt",
+      });
+
+      const client = await orchestrator.createClient({
+        clientName: "Client A",
+      });
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(10, 0, 0, 0);
+
+      const tomorrowEnd = new Date(tomorrow);
+      tomorrowEnd.setMinutes(tomorrowEnd.getMinutes() + 30);
+
+      const appointment = await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: tomorrow,
+        appointmentEndDatetime: tomorrowEnd,
+        totalDuration: 30,
+        status: "AGENDADO",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+      expect(responseBody.cancelled_appointments_count).toBeGreaterThanOrEqual(
+        1,
+      );
+
+      const dbAppointment = await db.appointment.findUnique({
+        where: { appointmentId: appointment.appointmentId },
+        select: { status: true },
+      });
+
+      expect(dbAppointment.status).toBe("CANCELADO");
+    });
+
+    test("Past AGENDADO appointments are NOT cancelled", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber with past appt",
+      });
+
+      const client = await orchestrator.createClient({
+        clientName: "Client B",
+      });
+
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      yesterday.setHours(10, 0, 0, 0);
+
+      const yesterdayEnd = new Date(yesterday);
+      yesterdayEnd.setMinutes(yesterdayEnd.getMinutes() + 30);
+
+      const pastAppointment = await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: yesterday,
+        appointmentEndDatetime: yesterdayEnd,
+        totalDuration: 30,
+        status: "AGENDADO",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const dbAppointment = await db.appointment.findUnique({
+        where: { appointmentId: pastAppointment.appointmentId },
+        select: { status: true },
+      });
+
+      expect(dbAppointment.status).toBe("AGENDADO");
+    });
+
+    test("Appointments from other barbers are NOT cancelled", async () => {
+      const barberA = await orchestrator.createBarber({
+        barberName: "Barber A (deleted)",
+      });
+
+      const barberB = await orchestrator.createBarber({
+        barberName: "Barber B (untouched)",
+      });
+
+      const client = await orchestrator.createClient({
+        clientName: "Client C",
+      });
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(14, 0, 0, 0);
+
+      const tomorrowEnd = new Date(tomorrow);
+      tomorrowEnd.setMinutes(tomorrowEnd.getMinutes() + 30);
+
+      const barberBAppointment = await orchestrator.createAppointment({
+        barberId: barberB.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: tomorrow,
+        appointmentEndDatetime: tomorrowEnd,
+        totalDuration: 30,
+        status: "AGENDADO",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barberA.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const dbAppointment = await db.appointment.findUnique({
+        where: { appointmentId: barberBAppointment.appointmentId },
+        select: { status: true },
+      });
+
+      expect(dbAppointment.status).toBe("AGENDADO");
+    });
+
+    test("CONCLUIDO, FALTOU, and CANCELADO appointments are NOT modified", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber with various statuses",
+      });
+
+      const client = await orchestrator.createClient({
+        clientName: "Client D",
+      });
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+
+      function makeFutureTime(hour) {
+        const dt = new Date(tomorrow);
+        dt.setHours(hour, 0, 0, 0);
+        const dtEnd = new Date(dt);
+        dtEnd.setMinutes(dtEnd.getMinutes() + 30);
+        return { start: dt, end: dtEnd };
+      }
+
+      const time1 = makeFutureTime(9);
+      const time2 = makeFutureTime(11);
+      const time3 = makeFutureTime(15);
+
+      const concluidoAppt = await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: time1.start,
+        appointmentEndDatetime: time1.end,
+        totalDuration: 30,
+        status: "CONCLUIDO",
+      });
+
+      const faltouAppt = await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: time2.start,
+        appointmentEndDatetime: time2.end,
+        totalDuration: 30,
+        status: "FALTOU",
+      });
+
+      const canceladoAppt = await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: time3.start,
+        appointmentEndDatetime: time3.end,
+        totalDuration: 30,
+        status: "CANCELADO",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const dbConcluido = await db.appointment.findUnique({
+        where: { appointmentId: concluidoAppt.appointmentId },
+        select: { status: true },
+      });
+      expect(dbConcluido.status).toBe("CONCLUIDO");
+
+      const dbFaltou = await db.appointment.findUnique({
+        where: { appointmentId: faltouAppt.appointmentId },
+        select: { status: true },
+      });
+      expect(dbFaltou.status).toBe("FALTOU");
+
+      const dbCancelado = await db.appointment.findUnique({
+        where: { appointmentId: canceladoAppt.appointmentId },
+        select: { status: true },
+      });
+      expect(dbCancelado.status).toBe("CANCELADO");
+    });
+  });
+});

--- a/src/tests/integration/api/v1/services/delete.test.js
+++ b/src/tests/integration/api/v1/services/delete.test.js
@@ -1,0 +1,225 @@
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+import { prisma as db } from "@/infra/prisma.js";
+
+describe("DELETE /api/v1/services/[service_id]", () => {
+  describe("Anonymous user", () => {
+    test("Cannot delete service (401)", async () => {
+      await orchestrator.clearDatabase();
+
+      const service = await orchestrator.createService({
+        serviceName: "Service to delete",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "DELETE",
+        },
+      );
+
+      expect(response.status).toBe(401);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("UnauthorizedError");
+    });
+  });
+
+  describe("Authenticated Barber user", () => {
+    test("Cannot delete service (403)", async () => {
+      const barberUser = await orchestrator.createUser({
+        accessLevel: "barber",
+      });
+      const session = await orchestrator.createSession(barberUser.userId);
+
+      const service = await orchestrator.createService({
+        serviceName: "Service barber cannot delete",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${session.token}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(403);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ForbiddenError");
+    });
+  });
+
+  describe("Authenticated Admin user", () => {
+    let adminSessionToken;
+
+    beforeAll(async () => {
+      const adminUser = await orchestrator.createUser({
+        accessLevel: "admin",
+      });
+      const session = await orchestrator.createSession(adminUser.userId);
+      adminSessionToken = session.token;
+    });
+
+    test("Can soft-delete an active service (200)", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Service to soft-delete",
+        serviceDescription: "Will be deactivated",
+        duration: 30,
+        price: 50,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(
+        expect.objectContaining({
+          service_id: service.serviceId,
+          service_name: "Service to soft-delete",
+          service_description: "Will be deactivated",
+          duration: 30,
+          price: "50.00",
+          is_active: false,
+        }),
+      );
+      expect(responseBody.created_at).toBeDefined();
+      expect(responseBody.updated_at).toBeDefined();
+    });
+
+    test("Soft-deleted service no longer appears in GET /api/v1/services", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Service that will vanish from list",
+        isActive: true,
+      });
+
+      // Soft-delete it
+      const deleteResponse = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(deleteResponse.status).toBe(200);
+
+      // Verify it does not appear in the public list
+      const getResponse = await fetch(`${webserver.origin}/api/v1/services`);
+      expect(getResponse.status).toBe(200);
+
+      const services = await getResponse.json();
+      const serviceIds = services.map((s) => s.service_id);
+      expect(serviceIds).not.toContain(service.serviceId);
+    });
+
+    test("Service row still exists in database with isActive = false", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Service still in DB",
+        isActive: true,
+      });
+
+      // Soft-delete it
+      const deleteResponse = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(deleteResponse.status).toBe(200);
+
+      // Verify the row still exists in the database
+      const dbService = await db.service.findUnique({
+        where: { serviceId: service.serviceId },
+        select: {
+          serviceId: true,
+          serviceName: true,
+          isActive: true,
+        },
+      });
+
+      expect(dbService).not.toBeNull();
+      expect(dbService.serviceId).toBe(service.serviceId);
+      expect(dbService.serviceName).toBe("Service still in DB");
+      expect(dbService.isActive).toBe(false);
+    });
+
+    test("Deleting an already inactive service is idempotent (200)", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Already inactive",
+        isActive: false,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(
+        expect.objectContaining({
+          service_id: service.serviceId,
+          service_name: "Already inactive",
+          is_active: false,
+        }),
+      );
+    });
+
+    test("Nonexistent valid service_id (404)", async () => {
+      const fakeUuid = "00000000-0000-4000-a000-000000000000";
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${fakeUuid}`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(404);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("NotFoundError");
+    });
+
+    test("Invalid service_id format (400)", async () => {
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/not-a-uuid`,
+        {
+          method: "DELETE",
+          headers: {
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+        },
+      );
+
+      expect(response.status).toBe(400);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ValidationError");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements admin-only soft deletion for services and barbers, and connects the dashboard delete actions to the real API endpoints.

Services are removed from the active services list through soft deletion. Barbers are also soft deleted, and future appointments linked to deleted barbers are cancelled according to the MVP behavior.

## Main changes

- Added service soft delete flow
  - Adds `DELETE /api/v1/services/[service_id]`
  - Restricts deletion to admin users
  - Soft deletes services instead of removing database records
  - Adds integration tests for service deletion behavior

- Added barber soft delete flow
  - Adds `DELETE /api/v1/barbers/[barber_id]`
  - Restricts deletion to admin users
  - Soft deletes barbers instead of removing database records
  - Cancels future appointments linked to deleted barbers
  - Adds integration tests for barber deletion behavior

- Connected dashboard delete actions
  - Services dashboard now calls the service delete endpoint
  - Employees dashboard now calls the barber delete endpoint
  - Adds confirmation dialogs before deletion
  - Adds loading dialogs during deletion
  - Adds error banners for failed delete requests
  - Removes deleted items from local dashboard state after successful deletion

## Notes

This PR keeps deleted services and barbers in the database for historical consistency, while removing them from active management views.

The employee deletion flow treats existing future appointments as a special case: they are cancelled instead of being left assigned to an inactive barber.