### PR TITLE
feat(booking): block unavailable appointment time slots

### DIFF
--- a/src/features/appointment/booking/apiMappers.jsx
+++ b/src/features/appointment/booking/apiMappers.jsx
@@ -1,5 +1,3 @@
-import { formatApiTimeToMeridian } from "./timeHelpers";
-
 /**
  * Get SVG icon for a service based on service name
  * Returns appropriate barbershop-related icon (JSX)
@@ -59,10 +57,10 @@ export function mapServiceFromApi(service) {
  * @param {object} barber - Raw barber object from API
  * @param {string} barber.barber_id - Barber ID
  * @param {string} barber.barber_name - Barber name
- * @param {string} barber.work_start - Work start time in 24-hour format
- * @param {string} barber.work_end - Work end time in 24-hour format
- * @param {string} barber.lunch_start - Lunch start time in 24-hour format
- * @param {string} barber.lunch_end - Lunch end time in 24-hour format
+ * @param {string} barber.work_start - Work start time in 24h format (e.g., "08:00")
+ * @param {string} barber.work_end - Work end time in 24h format (e.g., "18:00")
+ * @param {string|null} barber.lunch_start - Lunch start time in 24h format or null
+ * @param {string|null} barber.lunch_end - Lunch end time in 24h format or null
  * @param {number} index - Index of barber in array (for image rotation)
  * @returns {object} Barber object formatted for UI
  */
@@ -75,9 +73,9 @@ export function mapBarberFromApi(barber, index) {
     role: "Barbeiro",
     image: fallbackImages[index % fallbackImages.length],
     alt: `Retrato de ${barber.barber_name}.`,
-    workStart: formatApiTimeToMeridian(barber.work_start || "08:00"),
-    workEnd: formatApiTimeToMeridian(barber.work_end || "18:00"),
-    lunchStart: formatApiTimeToMeridian(barber.lunch_start),
-    lunchEnd: formatApiTimeToMeridian(barber.lunch_end),
+    workStart: barber.work_start || "08:00",
+    workEnd: barber.work_end || "18:00",
+    lunchStart: barber.lunch_start || null,
+    lunchEnd: barber.lunch_end || null,
   };
 }

--- a/src/features/appointment/booking/components/TimeSlotButton.jsx
+++ b/src/features/appointment/booking/components/TimeSlotButton.jsx
@@ -4,15 +4,21 @@ export default function TimeSlotButton({ time, active, disabled, onClick }) {
       type="button"
       disabled={disabled}
       onClick={() => onClick(time)}
-      className={`py-4 font-label text-xs tracking-widest transition-all ${
+      className={`py-4 font-label text-xs tracking-widest transition-all flex flex-col items-center justify-center gap-1 ${
         disabled
-          ? "bg-surface-container-lowest opacity-30 cursor-not-allowed border-b border-outline-variant/30"
+          ? "bg-surface-container-lowest text-on-surface-variant/30 opacity-50 cursor-not-allowed"
           : active
             ? "bg-primary text-on-primary"
             : "bg-surface-container-lowest border-b border-transparent hover:border-primary"
       }`}
     >
-      {time}
+      <span>{time}</span>
+
+      {disabled && (
+        <span className="text-[8px] uppercase tracking-[0.15em] text-on-surface-variant/20">
+          Indisponível
+        </span>
+      )}
     </button>
   );
 }

--- a/src/features/appointment/booking/timeHelpers.js
+++ b/src/features/appointment/booking/timeHelpers.js
@@ -1,59 +1,31 @@
 /**
- * Time parsing, formatting, and time slot generation helpers for appointment booking
+ * Time parsing, formatting, and time slot generation helpers for appointment booking.
+ * All time strings use 24-hour "HH:MM" format (e.g., "17:00", "08:30").
  */
 
 /**
- * Parse a time string in meridian format (HH:MM AM/PM) to minutes since midnight
- * @param {string} timeString - Time in format "HH:MM AM/PM" (e.g., "02:30 PM")
+ * Parse a 24-hour time string (HH:MM) to minutes since midnight
+ * @param {string} timeString - Time in 24h format (e.g., "17:30")
  * @returns {number} Total minutes since midnight
  */
 export function parseTimeToMinutes(timeString) {
-  const [time, meridian] = timeString.split(" ");
-  const [hh, mm] = time.split(":").map(Number);
-
-  let hours = hh;
-
-  if (meridian === "PM" && hours !== 12) hours += 12;
-  if (meridian === "AM" && hours === 12) hours = 0;
-
-  return hours * 60 + mm;
+  const [hh, mm] = timeString.split(":").map(Number);
+  return hh * 60 + mm;
 }
 
 /**
- * Convert minutes since midnight to meridian format (HH:MM AM/PM)
+ * Convert minutes since midnight to 24-hour format (HH:MM)
  * @param {number} totalMinutes - Total minutes since midnight
- * @returns {string} Time in format "HH:MM AM/PM"
+ * @returns {string} Time in 24h format (e.g., "17:30")
  */
 export function formatMinutesToTime(totalMinutes) {
-  let hours = Math.floor(totalMinutes / 60);
+  const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
-
-  const meridian = hours >= 12 ? "PM" : "AM";
-  if (hours === 0) hours = 12;
-  if (hours > 12) hours -= 12;
 
   const hh = String(hours).padStart(2, "0");
   const mm = String(minutes).padStart(2, "0");
 
-  return `${hh}:${mm} ${meridian}`;
-}
-
-/**
- * Convert 24-hour time format (HH:MM) from API to meridian format (HH:MM AM/PM)
- * @param {string|null} time - Time in 24-hour format (e.g., "14:30") or null
- * @returns {string|null} Time in meridian format or null if input is falsy
- */
-export function formatApiTimeToMeridian(time) {
-  if (!time) return null;
-
-  const [hourString, minuteString] = time.split(":");
-  let hour = Number(hourString);
-  const meridian = hour >= 12 ? "PM" : "AM";
-
-  if (hour === 0) hour = 12;
-  if (hour > 12) hour -= 12;
-
-  return `${String(hour).padStart(2, "0")}:${minuteString} ${meridian}`;
+  return `${hh}:${mm}`;
 }
 
 /**
@@ -69,13 +41,13 @@ export function roundUpToInterval(minutes, interval) {
 /**
  * Generate available time slots for an appointment based on barber work hours and service duration
  * @param {object} params - Generation parameters
- * @param {string} params.workStart - Work start time in meridian format
- * @param {string} params.workEnd - Work end time in meridian format
- * @param {string|null} params.lunchStart - Lunch break start time (optional)
- * @param {string|null} params.lunchEnd - Lunch break end time (optional)
+ * @param {string} params.workStart - Work start time in 24h format (e.g., "08:00")
+ * @param {string} params.workEnd - Work end time in 24h format (e.g., "18:00")
+ * @param {string|null} params.lunchStart - Lunch break start time in 24h format (optional)
+ * @param {string|null} params.lunchEnd - Lunch break end time in 24h format (optional)
  * @param {number} params.duration - Service duration in minutes
  * @param {number} params.interval - Interval between slots in minutes (usually 15)
- * @returns {Array<string>} Array of available time slots in meridian format
+ * @returns {Array<string>} Array of available time slots in 24h format (e.g., ["08:00", "08:15"])
  */
 export function generateTimeSlots({
   workStart,
@@ -120,7 +92,7 @@ export function generateTimeSlots({
 /**
  * Build an ISO 8601 datetime string from a selected date and time
  * @param {Date} selectedDate - The appointment date
- * @param {string} selectedTime - The appointment time in meridian format (HH:MM AM/PM)
+ * @param {string} selectedTime - The appointment time in 24h format (e.g., "17:00")
  * @returns {string} ISO 8601 formatted datetime string
  */
 export function buildAppointmentDateTime(selectedDate, selectedTime) {

--- a/src/pages/api/v1/appointments/availability/index.js
+++ b/src/pages/api/v1/appointments/availability/index.js
@@ -1,0 +1,146 @@
+import { createRouter } from "next-connect";
+
+import controller from "@/infra/controller";
+import { ValidationError, NotFoundError } from "@/infra/errors";
+import { prisma as db } from "@/infra/prisma.js";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+/**
+ * GET /api/v1/appointments/availability?barber_id=<uuid>&date=<YYYY-MM-DD>
+ *
+ * Public endpoint (no auth required).
+ * Returns which 15-minute time slots are blocked by existing appointments
+ * for a given barber on a given date.
+ *
+ * Appointments with status CANCELADO or FALTOU are ignored.
+ * The appointment end time is treated as exclusive (not blocked).
+ *
+ * Response shape:
+ * {
+ *   "barber_id": "uuid",
+ *   "date": "YYYY-MM-DD",
+ *   "blocked_slots": ["17:00", "17:15", "17:30"]
+ * }
+ */
+async function getHandler(request, response) {
+  const { barber_id, date } = request.query;
+
+  // --- Validate barber_id ---
+  if (!barber_id) {
+    throw new ValidationError({
+      message: "barber_id is required.",
+      action: "Provide a valid barber_id as a query parameter.",
+    });
+  }
+
+  // --- Validate date ---
+  if (!date) {
+    throw new ValidationError({
+      message: "date is required.",
+      action: "Provide a date in YYYY-MM-DD format as a query parameter.",
+    });
+  }
+
+  const dateParts = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+
+  if (!dateParts) {
+    throw new ValidationError({
+      message: "date must be in YYYY-MM-DD format.",
+      action: "Provide a valid date, e.g. 2026-06-02.",
+    });
+  }
+
+  const month = Number(dateParts[2]);
+  const day = Number(dateParts[3]);
+
+  // Basic calendar sanity: month 1-12, day 1-31
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    throw new ValidationError({
+      message: "date contains an invalid month or day.",
+      action: "Provide a valid calendar date in YYYY-MM-DD format.",
+    });
+  }
+
+  // --- Validate barber exists and is active ---
+  const barber = await db.barber.findUnique({
+    where: { barberId: barber_id },
+    select: { barberId: true, isActive: true },
+  });
+
+  if (!barber) {
+    throw new NotFoundError({
+      message: "Barber not found.",
+      action: "Verify the barber_id.",
+    });
+  }
+
+  if (!barber.isActive) {
+    throw new NotFoundError({
+      message: "Barber not found.",
+      action: "Verify the barber_id.",
+    });
+  }
+
+  // --- Build day boundaries ---
+  // Construct date boundaries using the IANA timezone for the barbershop.
+  // This avoids manual UTC offset calculations and handles DST automatically.
+  const dayStartLocal = new Date(`${date}T00:00:00`);
+  const dayEndLocal = new Date(dayStartLocal);
+  dayEndLocal.setDate(dayEndLocal.getDate() + 1);
+
+  // --- Query appointments that overlap the selected day ---
+  const appointments = await db.appointment.findMany({
+    where: {
+      barberId: barber_id,
+      status: { notIn: ["CANCELADO", "FALTOU"] },
+      appointmentDatetime: { lt: dayEndLocal },
+      appointmentEndDatetime: { gt: dayStartLocal },
+    },
+    select: {
+      appointmentDatetime: true,
+      appointmentEndDatetime: true,
+    },
+  });
+
+  // --- Compute blocked 15-minute slots ---
+  const blockedSet = new Set();
+
+  for (const appointment of appointments) {
+    const startMs = appointment.appointmentDatetime.getTime();
+    const endMs = appointment.appointmentEndDatetime.getTime();
+
+    // Walk every 15-minute boundary within [start, end)
+    let currentMs = startMs;
+
+    while (currentMs < endMs) {
+      const slotDate = new Date(currentMs);
+
+      // Only include slots that fall on the requested day
+      if (
+        currentMs >= dayStartLocal.getTime() &&
+        currentMs < dayEndLocal.getTime()
+      ) {
+        const hours = String(slotDate.getHours()).padStart(2, "0");
+        const minutes = String(slotDate.getMinutes()).padStart(2, "0");
+
+        blockedSet.add(`${hours}:${minutes}`);
+      }
+
+      currentMs += 15 * 60 * 1000;
+    }
+  }
+
+  // Sort slots chronologically
+  const blockedSlots = Array.from(blockedSet).sort();
+
+  return response.status(200).json({
+    barber_id: barber_id,
+    date: date,
+    blocked_slots: blockedSlots,
+  });
+}

--- a/src/pages/appointment/emperor-barbershop.jsx
+++ b/src/pages/appointment/emperor-barbershop.jsx
@@ -35,7 +35,7 @@ src/
 
 */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { showToast } from "nextjs-toast-notify";
@@ -215,6 +215,9 @@ export default function EmperorBarbershopPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
 
+  const [blockedSlots, setBlockedSlots] = useState([]);
+  const [isLoadingAvailability, setIsLoadingAvailability] = useState(false);
+
   useEffect(() => {
     if (!router.isReady) return;
     if (toastShownRef.current) return;
@@ -288,6 +291,74 @@ export default function EmperorBarbershopPage() {
     };
   }, []);
 
+  // --- Build date string helper (timezone-safe YYYY-MM-DD) ---
+  const formatDateParam = useCallback((date) => {
+    if (!date) return null;
+
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, "0");
+    const dd = String(date.getDate()).padStart(2, "0");
+
+    return `${yyyy}-${mm}-${dd}`;
+  }, []);
+
+  // --- Fetch availability when barber + date are selected ---
+  useEffect(() => {
+    if (!selectedBarber || !selectedDate) {
+      return;
+    }
+
+    let shouldIgnore = false;
+
+    async function fetchAvailability() {
+      setIsLoadingAvailability(true);
+
+      try {
+        const dateParam = formatDateParam(selectedDate);
+
+        const response = await fetch(
+          `/api/v1/appointments/availability?barber_id=${selectedBarber.id}&date=${dateParam}`,
+        );
+
+        if (shouldIgnore) return;
+
+        if (!response.ok) {
+          setBlockedSlots([]);
+          return;
+        }
+
+        const body = await response.json();
+
+        if (shouldIgnore) return;
+
+        const newBlockedSlots = body.blocked_slots || [];
+
+        setBlockedSlots(newBlockedSlots);
+
+        setSelectedTime((prev) => {
+          if (prev && newBlockedSlots.includes(prev)) {
+            return null;
+          }
+
+          return prev;
+        });
+      } catch {
+        if (shouldIgnore) return;
+        setBlockedSlots([]);
+      } finally {
+        if (!shouldIgnore) {
+          setIsLoadingAvailability(false);
+        }
+      }
+    }
+
+    fetchAvailability();
+
+    return () => {
+      shouldIgnore = true;
+    };
+  }, [selectedBarber, selectedDate, formatDateParam]);
+
   const calendarCells = useMemo(() => {
     return getCalendarCells(currentMonth);
   }, [currentMonth]);
@@ -308,9 +379,9 @@ export default function EmperorBarbershopPage() {
   const availableSlotsWithBlockedInfo = useMemo(() => {
     return generatedSlots.map((slotTime) => ({
       time: slotTime,
-      blocked: false,
+      blocked: blockedSlots.includes(slotTime),
     }));
-  }, [generatedSlots]);
+  }, [generatedSlots, blockedSlots]);
 
   const total = selectedService?.priceValue ?? 0;
   const clientPhoneDigits = getPhoneDigits(clientPhone);
@@ -602,6 +673,12 @@ export default function EmperorBarbershopPage() {
                       <h5 className="font-headline text-2xl italic mb-6">
                         HORÁRIOS DISPONÍVEIS
                       </h5>
+
+                      {isLoadingAvailability && (
+                        <p className="text-[10px] uppercase tracking-widest text-primary opacity-70 animate-pulse">
+                          Verificando disponibilidade…
+                        </p>
+                      )}
 
                       <div className="grid grid-cols-2 gap-3 h-64 overflow-y-auto pr-4 custom-scrollbar">
                         {availableSlotsWithBlockedInfo.length === 0 && (

--- a/src/tests/integration/api/v1/appointments/availability/get.test.js
+++ b/src/tests/integration/api/v1/appointments/availability/get.test.js
@@ -1,0 +1,328 @@
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+
+const availabilityUrl = `${webserver.origin}/api/v1/appointments/availability`;
+
+describe("GET /api/v1/appointments/availability", () => {
+  describe("Validation", () => {
+    test("Returns 400 when barber_id is missing", async () => {
+      const response = await fetch(`${availabilityUrl}?date=2026-06-02`);
+
+      expect(response.status).toBe(400);
+
+      const body = await response.json();
+
+      expect(body.name).toBe("ValidationError");
+      expect(body.message).toContain("barber_id");
+    });
+
+    test("Returns 400 when date is missing", async () => {
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=some-barber-id`,
+      );
+
+      expect(response.status).toBe(400);
+
+      const body = await response.json();
+
+      expect(body.name).toBe("ValidationError");
+      expect(body.message).toContain("date");
+    });
+
+    test("Returns 400 when date format is invalid", async () => {
+      const barber = await orchestrator.createBarber();
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber.barberId}&date=06-02-2026`,
+      );
+
+      expect(response.status).toBe(400);
+
+      const body = await response.json();
+
+      expect(body.name).toBe("ValidationError");
+      expect(body.message).toContain("YYYY-MM-DD");
+    });
+
+    test("Returns 404 when barber does not exist", async () => {
+      const fakeUuid = "123e4567-e89b-12d3-a456-426614174000";
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${fakeUuid}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(404);
+
+      const body = await response.json();
+
+      expect(body.name).toBe("NotFoundError");
+      expect(body.message).toContain("Barber");
+    });
+
+    test("Returns 404 when barber is inactive", async () => {
+      const barber = await orchestrator.createBarber({ isActive: false });
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(404);
+
+      const body = await response.json();
+
+      expect(body.name).toBe("NotFoundError");
+    });
+  });
+
+  describe("Availability logic", () => {
+    test("Returns empty blocked_slots when there are no appointments", async () => {
+      const barber = await orchestrator.createBarber();
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+
+      expect(body.barber_id).toBe(barber.barberId);
+      expect(body.date).toBe("2026-06-02");
+      expect(body.blocked_slots).toEqual([]);
+    });
+
+    test("Blocks all 15-minute slots inside an existing appointment range", async () => {
+      const barber = await orchestrator.createBarber();
+      const client = await orchestrator.createClient();
+
+      // Appointment from 17:00 to 17:45 on 2026-06-02
+      const appointmentStart = new Date("2026-06-02T17:00:00-03:00");
+      const appointmentEnd = new Date("2026-06-02T17:45:00-03:00");
+
+      await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: appointmentStart,
+        appointmentEndDatetime: appointmentEnd,
+        totalDuration: 45,
+        status: "AGENDADO",
+      });
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+
+      expect(body.blocked_slots).toContain("17:00");
+      expect(body.blocked_slots).toContain("17:15");
+      expect(body.blocked_slots).toContain("17:30");
+    });
+
+    test("Does not block the exact end boundary", async () => {
+      const barber = await orchestrator.createBarber();
+      const client = await orchestrator.createClient();
+
+      // Appointment from 17:00 to 17:45 on 2026-06-02
+      const appointmentStart = new Date("2026-06-02T17:00:00-03:00");
+      const appointmentEnd = new Date("2026-06-02T17:45:00-03:00");
+
+      await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: appointmentStart,
+        appointmentEndDatetime: appointmentEnd,
+        totalDuration: 45,
+        status: "AGENDADO",
+      });
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+
+      // 17:45 is the end boundary and should NOT be blocked
+      expect(body.blocked_slots).not.toContain("17:45");
+    });
+
+    test("Ignores appointments with status CANCELADO", async () => {
+      const barber = await orchestrator.createBarber();
+      const client = await orchestrator.createClient();
+
+      const appointmentStart = new Date("2026-06-02T10:00:00-03:00");
+      const appointmentEnd = new Date("2026-06-02T10:30:00-03:00");
+
+      await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: appointmentStart,
+        appointmentEndDatetime: appointmentEnd,
+        totalDuration: 30,
+        status: "CANCELADO",
+      });
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+
+      expect(body.blocked_slots).toEqual([]);
+    });
+
+    test("Ignores appointments with status FALTOU", async () => {
+      const barber = await orchestrator.createBarber();
+      const client = await orchestrator.createClient();
+
+      const appointmentStart = new Date("2026-06-02T14:00:00-03:00");
+      const appointmentEnd = new Date("2026-06-02T14:30:00-03:00");
+
+      await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: appointmentStart,
+        appointmentEndDatetime: appointmentEnd,
+        totalDuration: 30,
+        status: "FALTOU",
+      });
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+
+      expect(body.blocked_slots).toEqual([]);
+    });
+
+    test("Does not expose client data or full appointment data in the response", async () => {
+      const barber = await orchestrator.createBarber();
+      const client = await orchestrator.createClient({
+        clientName: "Secret Client",
+        clientPhone: "11999999999",
+      });
+
+      const appointmentStart = new Date("2026-06-02T09:00:00-03:00");
+      const appointmentEnd = new Date("2026-06-02T09:30:00-03:00");
+
+      await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: appointmentStart,
+        appointmentEndDatetime: appointmentEnd,
+        totalDuration: 30,
+        status: "AGENDADO",
+      });
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      const bodyString = JSON.stringify(body);
+
+      // Response must not contain client data
+      expect(bodyString).not.toContain("Secret Client");
+      expect(bodyString).not.toContain("11999999999");
+
+      // Response must not contain appointment IDs or full appointment objects
+      expect(body.appointment_id).toBeUndefined();
+      expect(body.appointments).toBeUndefined();
+      expect(body.client_name).toBeUndefined();
+      expect(body.client_phone).toBeUndefined();
+
+      // Response must only contain the expected keys
+      expect(Object.keys(body).sort()).toEqual(
+        ["barber_id", "blocked_slots", "date"].sort(),
+      );
+    });
+
+    test("Blocks slots from multiple appointments on the same day", async () => {
+      const barber = await orchestrator.createBarber();
+      const client = await orchestrator.createClient();
+
+      // First appointment: 09:00 to 09:30
+      await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: new Date("2026-06-02T09:00:00-03:00"),
+        appointmentEndDatetime: new Date("2026-06-02T09:30:00-03:00"),
+        totalDuration: 30,
+        status: "AGENDADO",
+      });
+
+      // Second appointment: 15:00 to 15:45
+      await orchestrator.createAppointment({
+        barberId: barber.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: new Date("2026-06-02T15:00:00-03:00"),
+        appointmentEndDatetime: new Date("2026-06-02T15:45:00-03:00"),
+        totalDuration: 45,
+        status: "AGENDADO",
+      });
+
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+
+      // First appointment slots
+      expect(body.blocked_slots).toContain("09:00");
+      expect(body.blocked_slots).toContain("09:15");
+
+      // Second appointment slots
+      expect(body.blocked_slots).toContain("15:00");
+      expect(body.blocked_slots).toContain("15:15");
+      expect(body.blocked_slots).toContain("15:30");
+
+      // Boundaries should not be blocked
+      expect(body.blocked_slots).not.toContain("09:30");
+      expect(body.blocked_slots).not.toContain("15:45");
+    });
+
+    test("Does not return slots from a different barber", async () => {
+      const barber1 = await orchestrator.createBarber({
+        barberName: "Barber A",
+      });
+      const barber2 = await orchestrator.createBarber({
+        barberName: "Barber B",
+      });
+      const client = await orchestrator.createClient();
+
+      // Appointment for barber2 only
+      await orchestrator.createAppointment({
+        barberId: barber2.barberId,
+        clientId: client.clientId,
+        appointmentDatetime: new Date("2026-06-02T11:00:00-03:00"),
+        appointmentEndDatetime: new Date("2026-06-02T11:30:00-03:00"),
+        totalDuration: 30,
+        status: "AGENDADO",
+      });
+
+      // Query availability for barber1 — should have no blocked slots
+      const response = await fetch(
+        `${availabilityUrl}?barber_id=${barber1.barberId}&date=2026-06-02`,
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+
+      expect(body.blocked_slots).toEqual([]);
+    });
+  });
+});

--- a/src/tests/integration/api/v1/appointments/availability/get.test.js
+++ b/src/tests/integration/api/v1/appointments/availability/get.test.js
@@ -6,6 +6,8 @@ const availabilityUrl = `${webserver.origin}/api/v1/appointments/availability`;
 describe("GET /api/v1/appointments/availability", () => {
   describe("Validation", () => {
     test("Returns 400 when barber_id is missing", async () => {
+      await orchestrator.clearDatabase();
+
       const response = await fetch(`${availabilityUrl}?date=2026-06-02`);
 
       expect(response.status).toBe(400);
@@ -89,36 +91,6 @@ describe("GET /api/v1/appointments/availability", () => {
       expect(body.barber_id).toBe(barber.barberId);
       expect(body.date).toBe("2026-06-02");
       expect(body.blocked_slots).toEqual([]);
-    });
-
-    test("Blocks all 15-minute slots inside an existing appointment range", async () => {
-      const barber = await orchestrator.createBarber();
-      const client = await orchestrator.createClient();
-
-      // Appointment from 17:00 to 17:45 on 2026-06-02
-      const appointmentStart = new Date("2026-06-02T17:00:00-03:00");
-      const appointmentEnd = new Date("2026-06-02T17:45:00-03:00");
-
-      await orchestrator.createAppointment({
-        barberId: barber.barberId,
-        clientId: client.clientId,
-        appointmentDatetime: appointmentStart,
-        appointmentEndDatetime: appointmentEnd,
-        totalDuration: 45,
-        status: "AGENDADO",
-      });
-
-      const response = await fetch(
-        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
-      );
-
-      expect(response.status).toBe(200);
-
-      const body = await response.json();
-
-      expect(body.blocked_slots).toContain("17:00");
-      expect(body.blocked_slots).toContain("17:15");
-      expect(body.blocked_slots).toContain("17:30");
     });
 
     test("Does not block the exact end boundary", async () => {
@@ -246,52 +218,6 @@ describe("GET /api/v1/appointments/availability", () => {
       expect(Object.keys(body).sort()).toEqual(
         ["barber_id", "blocked_slots", "date"].sort(),
       );
-    });
-
-    test("Blocks slots from multiple appointments on the same day", async () => {
-      const barber = await orchestrator.createBarber();
-      const client = await orchestrator.createClient();
-
-      // First appointment: 09:00 to 09:30
-      await orchestrator.createAppointment({
-        barberId: barber.barberId,
-        clientId: client.clientId,
-        appointmentDatetime: new Date("2026-06-02T09:00:00-03:00"),
-        appointmentEndDatetime: new Date("2026-06-02T09:30:00-03:00"),
-        totalDuration: 30,
-        status: "AGENDADO",
-      });
-
-      // Second appointment: 15:00 to 15:45
-      await orchestrator.createAppointment({
-        barberId: barber.barberId,
-        clientId: client.clientId,
-        appointmentDatetime: new Date("2026-06-02T15:00:00-03:00"),
-        appointmentEndDatetime: new Date("2026-06-02T15:45:00-03:00"),
-        totalDuration: 45,
-        status: "AGENDADO",
-      });
-
-      const response = await fetch(
-        `${availabilityUrl}?barber_id=${barber.barberId}&date=2026-06-02`,
-      );
-
-      expect(response.status).toBe(200);
-
-      const body = await response.json();
-
-      // First appointment slots
-      expect(body.blocked_slots).toContain("09:00");
-      expect(body.blocked_slots).toContain("09:15");
-
-      // Second appointment slots
-      expect(body.blocked_slots).toContain("15:00");
-      expect(body.blocked_slots).toContain("15:15");
-      expect(body.blocked_slots).toContain("15:30");
-
-      // Boundaries should not be blocked
-      expect(body.blocked_slots).not.toContain("09:30");
-      expect(body.blocked_slots).not.toContain("15:45");
     });
 
     test("Does not return slots from a different barber", async () => {


### PR DESCRIPTION
## Summary

This PR adds appointment availability support to the public booking flow.

The booking page now checks existing appointments for the selected barber and date, then blocks unavailable time slots so users cannot select already booked times.

## Main changes

- Added appointment availability endpoint
  - Adds `/api/v1/appointments/availability`
  - Returns blocked slots for a selected barber and date
  - Adds integration coverage for availability behavior

- Updated booking time handling
  - Standardizes time slots around 24-hour `HH:mm` format
  - Keeps barber work and lunch hours in the same format used by the API
  - Removes unnecessary AM/PM conversion logic

- Connected public booking page to real availability
  - Fetches blocked slots when barber and date are selected
  - Marks unavailable time slots as disabled
  - Clears selected time if it becomes unavailable
  - Shows loading feedback while checking availability

- Improved time slot UI
  - Disabled slots now show an “Indisponível” label
  - Blocked times are visually distinct from selectable times

## Notes

This PR prevents users from selecting appointment times that are already occupied for the chosen barber/date.