### PR TITLE
feat(booking): improve unavailable time slot handling

### DIFF
--- a/src/features/appointment/booking/components/TimeSlotButton.jsx
+++ b/src/features/appointment/booking/components/TimeSlotButton.jsx
@@ -1,4 +1,10 @@
-export default function TimeSlotButton({ time, active, disabled, onClick }) {
+export default function TimeSlotButton({
+  time,
+  active,
+  disabled,
+  disabledLabel = "Indisponível",
+  onClick,
+}) {
   return (
     <button
       type="button"
@@ -16,7 +22,7 @@ export default function TimeSlotButton({ time, active, disabled, onClick }) {
 
       {disabled && (
         <span className="text-[8px] uppercase tracking-[0.15em] text-on-surface-variant/20">
-          Indisponível
+          {disabledLabel}
         </span>
       )}
     </button>

--- a/src/pages/appointment/emperor-barbershop.jsx
+++ b/src/pages/appointment/emperor-barbershop.jsx
@@ -217,6 +217,9 @@ export default function EmperorBarbershopPage() {
 
   const [blockedSlots, setBlockedSlots] = useState([]);
   const [isLoadingAvailability, setIsLoadingAvailability] = useState(false);
+  const [isManualDateSelection, setIsManualDateSelection] = useState(false);
+  const [isSearchingNextDate, setIsSearchingNextDate] = useState(false);
+  const [noSlotsMessage, setNoSlotsMessage] = useState("");
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -479,6 +482,7 @@ export default function EmperorBarbershopPage() {
 
       setSelectedDate(firstValid);
       setSelectedTime(null);
+      setIsManualDateSelection(true);
 
       return newMonth;
     });
@@ -495,10 +499,129 @@ export default function EmperorBarbershopPage() {
 
       setSelectedDate(firstValid);
       setSelectedTime(null);
+      setIsManualDateSelection(true);
 
       return newMonth;
     });
   }
+
+  const searchNextAvailableDate = useCallback(
+    async (startDate) => {
+      setIsSearchingNextDate(true);
+      let foundDate = null;
+
+      for (let i = 1; i <= 30; i++) {
+        const nextDate = new Date(startDate);
+        nextDate.setDate(nextDate.getDate() + i);
+
+        const dateParam = formatDateParam(nextDate);
+
+        try {
+          const response = await fetch(
+            `/api/v1/appointments/availability?barber_id=${selectedBarber.id}&date=${dateParam}`,
+          );
+          if (!response.ok) continue;
+
+          const body = await response.json();
+          const newBlockedSlots = body.blocked_slots || [];
+
+          const slots = generateTimeSlots({
+            workStart: selectedBarber.workStart,
+            workEnd: selectedBarber.workEnd,
+            lunchStart: selectedBarber.lunchStart,
+            lunchEnd: selectedBarber.lunchEnd,
+            duration: selectedService.durationMinutes,
+            interval: 15,
+          });
+
+          const now = new Date();
+          const hasAvailable = slots.some((slotTime) => {
+            if (newBlockedSlots.includes(slotTime)) return false;
+
+            const [hours, minutes] = slotTime.split(":").map(Number);
+            const slotDate = new Date(
+              nextDate.getFullYear(),
+              nextDate.getMonth(),
+              nextDate.getDate(),
+              hours,
+              minutes,
+              0,
+              0,
+            );
+            if (slotDate <= now) return false;
+
+            return true;
+          });
+
+          if (hasAvailable) {
+            foundDate = nextDate;
+            break;
+          }
+        } catch {
+          // Ignore error and continue loop
+        }
+      }
+
+      if (foundDate) {
+        setSelectedDate(foundDate);
+        setSelectedTime(null);
+        setCurrentMonth((prevMonth) => {
+          if (
+            prevMonth.getFullYear() !== foundDate.getFullYear() ||
+            prevMonth.getMonth() !== foundDate.getMonth()
+          ) {
+            return new Date(foundDate.getFullYear(), foundDate.getMonth(), 1);
+          }
+          return prevMonth;
+        });
+        setNoSlotsMessage(
+          "A agenda desta data está completa. Mostramos o próximo dia disponível para você.",
+        );
+      } else {
+        setNoSlotsMessage(
+          "Não encontramos horários disponíveis nos próximos 30 dias.",
+        );
+      }
+
+      setIsManualDateSelection(true);
+      setIsSearchingNextDate(false);
+    },
+    [formatDateParam, selectedBarber, selectedService],
+  );
+
+  useEffect(() => {
+    if (
+      isLoadingAvailability ||
+      !selectedBarber ||
+      !selectedService ||
+      !selectedDate
+    ) {
+      return;
+    }
+
+    const hasAvailable = availableSlotsWithBlockedInfo.some((s) => !s.blocked);
+
+    if (!hasAvailable) {
+      if (isManualDateSelection) {
+        setTimeout(() => setNoSlotsMessage("Não há horários disponíveis para esta data."), 0);
+      } else {
+        if (!isSearchingNextDate) {
+          setTimeout(() => searchNextAvailableDate(selectedDate), 0);
+        }
+      }
+    } else {
+      setTimeout(() => setNoSlotsMessage(""), 0);
+    }
+  }, [
+    availableSlotsWithBlockedInfo,
+    isLoadingAvailability,
+    isManualDateSelection,
+    selectedBarber,
+    selectedService,
+    selectedDate,
+    isSearchingNextDate,
+    searchNextAvailableDate,
+  ]);
 
   async function handleConfirm() {
     if (!canConfirmAppointment) {
@@ -619,6 +742,7 @@ export default function EmperorBarbershopPage() {
                             setSelectedService(svc);
                             setSelectedTime(null);
                             setSubmitError("");
+                            setIsManualDateSelection(false);
                           }}
                         />
                       </div>
@@ -644,6 +768,7 @@ export default function EmperorBarbershopPage() {
                           setSelectedBarber(b);
                           setSelectedTime(null);
                           setSubmitError("");
+                          setIsManualDateSelection(false);
                         }}
                       />
                     ))}
@@ -709,6 +834,7 @@ export default function EmperorBarbershopPage() {
                               setSelectedDate(date);
                               setSelectedTime(null);
                               setSubmitError("");
+                              setIsManualDateSelection(true);
                             }}
                           />
                         ))}
@@ -720,13 +846,22 @@ export default function EmperorBarbershopPage() {
                         HORÁRIOS DISPONÍVEIS
                       </h5>
 
-                      {isLoadingAvailability && (
-                        <p className="text-[10px] uppercase tracking-widest text-primary opacity-70 animate-pulse">
-                          Verificando disponibilidade…
-                        </p>
+                      {noSlotsMessage && (
+                        <div className="bg-surface-container-lowest border-l-2 border-primary/50 p-3 mb-4">
+                          <p className="text-[10px] uppercase tracking-widest text-on-surface-variant opacity-80 leading-relaxed">
+                            {noSlotsMessage}
+                          </p>
+                        </div>
                       )}
 
-                      <div className="grid grid-cols-2 gap-3 h-64 overflow-y-auto pr-4 custom-scrollbar">
+                      {isLoadingAvailability || isSearchingNextDate ? (
+                        <p className="text-[10px] uppercase tracking-widest text-primary opacity-70 animate-pulse">
+                          {isSearchingNextDate
+                            ? "Buscando próximo horário disponível..."
+                            : "Verificando disponibilidade…"}
+                        </p>
+                      ) : (
+                        <div className="grid grid-cols-2 gap-3 h-64 overflow-y-auto pr-4 custom-scrollbar">
                         {availableSlotsWithBlockedInfo.length === 0 && (
                           <div className="col-span-2 text-on-surface-variant text-xs uppercase tracking-widest opacity-60">
                             Nenhum horário disponível
@@ -753,6 +888,7 @@ export default function EmperorBarbershopPage() {
                           />
                         ))}
                       </div>
+                    )}
 
                       {selectedService && (
                         <p className="text-[10px] uppercase tracking-widest text-on-surface-variant opacity-50">

--- a/src/pages/appointment/emperor-barbershop.jsx
+++ b/src/pages/appointment/emperor-barbershop.jsx
@@ -422,7 +422,9 @@ export default function EmperorBarbershopPage() {
 
   useEffect(() => {
     if (selectedTime) {
-      const slot = availableSlotsWithBlockedInfo.find((s) => s.time === selectedTime);
+      const slot = availableSlotsWithBlockedInfo.find(
+        (s) => s.time === selectedTime,
+      );
       if (slot && slot.blocked) {
         const timer = setTimeout(() => {
           setSelectedTime(null);
@@ -603,7 +605,11 @@ export default function EmperorBarbershopPage() {
 
     if (!hasAvailable) {
       if (isManualDateSelection) {
-        setTimeout(() => setNoSlotsMessage("Não há horários disponíveis para esta data."), 0);
+        setTimeout(
+          () =>
+            setNoSlotsMessage("Não há horários disponíveis para esta data."),
+          0,
+        );
       } else {
         if (!isSearchingNextDate) {
           setTimeout(() => searchNextAvailableDate(selectedDate), 0);
@@ -862,33 +868,33 @@ export default function EmperorBarbershopPage() {
                         </p>
                       ) : (
                         <div className="grid grid-cols-2 gap-3 h-64 overflow-y-auto pr-4 custom-scrollbar">
-                        {availableSlotsWithBlockedInfo.length === 0 && (
-                          <div className="col-span-2 text-on-surface-variant text-xs uppercase tracking-widest opacity-60">
-                            Nenhum horário disponível
-                          </div>
-                        )}
+                          {availableSlotsWithBlockedInfo.length === 0 && (
+                            <div className="col-span-2 text-on-surface-variant text-xs uppercase tracking-widest opacity-60">
+                              Nenhum horário disponível
+                            </div>
+                          )}
 
-                        {availableSlotsWithBlockedInfo.map((slot) => (
-                          <TimeSlotButton
-                            key={slot.time}
-                            time={slot.time}
-                            active={selectedTime === slot.time}
-                            disabled={slot.blocked}
-                            disabledLabel={
-                              slot.blockedReason === "past"
-                                ? "Horário passado"
-                                : "Indisponível"
-                            }
-                            onClick={(time) => {
-                              if (!slot.blocked) {
-                                setSelectedTime(time);
-                                setSubmitError("");
+                          {availableSlotsWithBlockedInfo.map((slot) => (
+                            <TimeSlotButton
+                              key={slot.time}
+                              time={slot.time}
+                              active={selectedTime === slot.time}
+                              disabled={slot.blocked}
+                              disabledLabel={
+                                slot.blockedReason === "past"
+                                  ? "Horário passado"
+                                  : "Indisponível"
                               }
-                            }}
-                          />
-                        ))}
-                      </div>
-                    )}
+                              onClick={(time) => {
+                                if (!slot.blocked) {
+                                  setSelectedTime(time);
+                                  setSubmitError("");
+                                }
+                              }}
+                            />
+                          ))}
+                        </div>
+                      )}
 
                       {selectedService && (
                         <p className="text-[10px] uppercase tracking-widest text-on-surface-variant opacity-50">

--- a/src/pages/appointment/emperor-barbershop.jsx
+++ b/src/pages/appointment/emperor-barbershop.jsx
@@ -377,11 +377,57 @@ export default function EmperorBarbershopPage() {
   }, [selectedBarber, selectedService]);
 
   const availableSlotsWithBlockedInfo = useMemo(() => {
-    return generatedSlots.map((slotTime) => ({
-      time: slotTime,
-      blocked: blockedSlots.includes(slotTime),
-    }));
-  }, [generatedSlots, blockedSlots]);
+    const now = new Date();
+
+    return generatedSlots.map((slotTime) => {
+      let isPast = false;
+
+      if (selectedDate) {
+        const [hours, minutes] = slotTime.split(":").map(Number);
+        const slotDate = new Date(
+          selectedDate.getFullYear(),
+          selectedDate.getMonth(),
+          selectedDate.getDate(),
+          hours,
+          minutes,
+          0,
+          0,
+        );
+
+        if (slotDate <= now) {
+          isPast = true;
+        }
+      }
+
+      const isBlockedByAppointment = blockedSlots.includes(slotTime);
+      const isBlocked = isBlockedByAppointment || isPast;
+
+      let blockedReason = null;
+      if (isPast) {
+        blockedReason = "past";
+      } else if (isBlockedByAppointment) {
+        blockedReason = "appointment";
+      }
+
+      return {
+        time: slotTime,
+        blocked: isBlocked,
+        blockedReason: blockedReason,
+      };
+    });
+  }, [generatedSlots, blockedSlots, selectedDate]);
+
+  useEffect(() => {
+    if (selectedTime) {
+      const slot = availableSlotsWithBlockedInfo.find((s) => s.time === selectedTime);
+      if (slot && slot.blocked) {
+        const timer = setTimeout(() => {
+          setSelectedTime(null);
+        }, 0);
+        return () => clearTimeout(timer);
+      }
+    }
+  }, [availableSlotsWithBlockedInfo, selectedTime]);
 
   const total = selectedService?.priceValue ?? 0;
   const clientPhoneDigits = getPhoneDigits(clientPhone);
@@ -693,6 +739,11 @@ export default function EmperorBarbershopPage() {
                             time={slot.time}
                             active={selectedTime === slot.time}
                             disabled={slot.blocked}
+                            disabledLabel={
+                              slot.blockedReason === "past"
+                                ? "Horário passado"
+                                : "Indisponível"
+                            }
                             onClick={(time) => {
                               if (!slot.blocked) {
                                 setSelectedTime(time);


### PR DESCRIPTION
## Summary

This PR improves the public booking page behavior around appointment time slot availability.

It prevents users from selecting past times, improves disabled slot labels, and adds a fallback flow that searches for the next date with available appointment slots when the selected date has no availability.

## Main changes

- Blocks past time slots
  - Prevents users from selecting times that have already passed on the selected date
  - Clears the selected time if it becomes invalid
  - Differentiates past slots from appointment-blocked slots

- Improves disabled slot labels
  - Adds support for custom disabled labels in `TimeSlotButton`
  - Shows “Horário passado” for past slots
  - Keeps “Indisponível” for unavailable/booked slots

- Adds next available date search
  - Searches upcoming dates when the selected date has no available slots
  - Shows loading feedback while searching availability
  - Displays a user-facing message when no slots are available for the current date

## Notes

This PR focuses on booking UX and availability handling in the public appointment flow. It builds on the existing availability endpoint integration and keeps users from choosing invalid or unavailable appointment times.