### PR TITLE
feat(admin): add edit flow for services and barbers

### DIFF
--- a/src/pages/api/v1/barbers/[barber_id]/index.js
+++ b/src/pages/api/v1/barbers/[barber_id]/index.js
@@ -10,6 +10,7 @@ import authorization from "@/infra/authorization.js";
 const router = createRouter();
 
 router.delete(deleteHandler);
+router.patch(patchHandler);
 
 export default router.handler(controller.errorHandlers);
 
@@ -120,6 +121,182 @@ async function deleteHandler(request, response) {
     barber: mapBarberResponse(updatedBarber),
     cancelled_appointments_count: cancelledCount,
   });
+}
+
+function isValidTimeFormat(timeString) {
+  if (!timeString) return true;
+  return /^([01][0-9]|2[0-3]):[0-5][0-9]$/.test(timeString);
+}
+
+function timeToMinutes(timeString) {
+  if (!timeString) return null;
+  const [hours, minutes] = timeString.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+async function patchHandler(request, response) {
+  const { user } =
+    await authentication.getAuthenticatedUserFromRequest(request);
+  authorization.ensureAdmin(user);
+
+  const barberId = extractBarberId(request);
+
+  if (Object.keys(request.body).length === 0) {
+    throw new ValidationError({
+      message: "The request body is empty.",
+      action: "Provide the fields to update.",
+    });
+  }
+
+  const {
+    barber_name,
+    phone_number,
+    work_start,
+    work_end,
+    lunch_start,
+    lunch_end,
+  } = request.body;
+
+  const dataToUpdate = {};
+
+  if (barber_name !== undefined) {
+    if (typeof barber_name !== "string" || barber_name.trim() === "") {
+      throw new ValidationError({
+        message: "O nome do barbeiro é obrigatório e não pode ser vazio.",
+        action: "Forneça um nome válido para o barbeiro.",
+      });
+    }
+    dataToUpdate.barberName = barber_name.trim();
+  }
+
+  if (phone_number !== undefined) {
+    dataToUpdate.phoneNumber = phone_number ? String(phone_number).trim() : null;
+  }
+
+  if (work_start !== undefined || work_end !== undefined) {
+    if (work_start === undefined || work_end === undefined) {
+      throw new ValidationError({
+        message: "É necessário fornecer o início e o fim do expediente.",
+        action: "Preencha os dois campos do expediente.",
+      });
+    }
+
+    if (!isValidTimeFormat(work_start) || !isValidTimeFormat(work_end)) {
+      throw new ValidationError({
+        message: "Formato de hora inválido para o expediente.",
+        action: "Forneça os horários no formato HH:mm.",
+      });
+    }
+
+    if (work_start && work_end) {
+      const startMin = timeToMinutes(work_start);
+      const endMin = timeToMinutes(work_end);
+      if (startMin >= endMin) {
+        throw new ValidationError({
+          message: "O início do expediente deve ser anterior ao fim.",
+          action: "Ajuste os horários do expediente.",
+        });
+      }
+    }
+
+    dataToUpdate.workStart = work_start || null;
+    dataToUpdate.workEnd = work_end || null;
+  }
+
+  if (lunch_start !== undefined || lunch_end !== undefined) {
+    if (lunch_start === undefined || lunch_end === undefined) {
+      throw new ValidationError({
+        message: "É necessário fornecer o início e o fim do horário de almoço.",
+        action: "Preencha os dois campos do horário de almoço.",
+      });
+    }
+
+    if (!isValidTimeFormat(lunch_start) || !isValidTimeFormat(lunch_end)) {
+      throw new ValidationError({
+        message: "Formato de hora inválido para o almoço.",
+        action: "Forneça os horários no formato HH:mm.",
+      });
+    }
+
+    if (lunch_start && lunch_end) {
+      const startMin = timeToMinutes(lunch_start);
+      const endMin = timeToMinutes(lunch_end);
+      if (startMin >= endMin) {
+        throw new ValidationError({
+          message: "O início do almoço deve ser anterior ao fim.",
+          action: "Ajuste os horários de almoço.",
+        });
+      }
+    }
+
+    dataToUpdate.lunchStart = lunch_start || null;
+    dataToUpdate.lunchEnd = lunch_end || null;
+  }
+
+  const existingBarber = await db.barber.findUnique({
+    where: { barberId },
+    select: {
+      isActive: true,
+      workStart: true,
+      workEnd: true,
+      lunchStart: true,
+      lunchEnd: true,
+    },
+  });
+
+  if (!existingBarber || !existingBarber.isActive) {
+    throw new NotFoundError({
+      message: "Barber not found or is inactive.",
+      action: "Verify if the barber_id is correct and the barber is active.",
+    });
+  }
+
+  if (Object.keys(dataToUpdate).length === 0) {
+    throw new ValidationError({
+      message: "Nenhum campo válido para atualização foi fornecido.",
+      action: "Forneça ao menos um campo válido.",
+    });
+  }
+
+  const finalWorkStart =
+    dataToUpdate.workStart !== undefined
+      ? dataToUpdate.workStart
+      : existingBarber.workStart;
+  const finalWorkEnd =
+    dataToUpdate.workEnd !== undefined
+      ? dataToUpdate.workEnd
+      : existingBarber.workEnd;
+  const finalLunchStart =
+    dataToUpdate.lunchStart !== undefined
+      ? dataToUpdate.lunchStart
+      : existingBarber.lunchStart;
+  const finalLunchEnd =
+    dataToUpdate.lunchEnd !== undefined
+      ? dataToUpdate.lunchEnd
+      : existingBarber.lunchEnd;
+
+  if (finalLunchStart && finalLunchEnd && finalWorkStart && finalWorkEnd) {
+    const wStart = timeToMinutes(finalWorkStart);
+    const wEnd = timeToMinutes(finalWorkEnd);
+    const lStart = timeToMinutes(finalLunchStart);
+    const lEnd = timeToMinutes(finalLunchEnd);
+
+    if (lStart < wStart || lEnd > wEnd) {
+      throw new ValidationError({
+        message: "O horário de almoço deve estar dentro do expediente.",
+        action:
+          "Ajuste os horários para que o almoço ocorra durante o expediente.",
+      });
+    }
+  }
+
+  const updatedBarber = await db.barber.update({
+    where: { barberId },
+    data: dataToUpdate,
+    select: barberSelect,
+  });
+
+  return response.status(200).json(mapBarberResponse(updatedBarber));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pages/api/v1/barbers/[barber_id]/index.js
+++ b/src/pages/api/v1/barbers/[barber_id]/index.js
@@ -170,7 +170,9 @@ async function patchHandler(request, response) {
   }
 
   if (phone_number !== undefined) {
-    dataToUpdate.phoneNumber = phone_number ? String(phone_number).trim() : null;
+    dataToUpdate.phoneNumber = phone_number
+      ? String(phone_number).trim()
+      : null;
   }
 
   if (work_start !== undefined || work_end !== undefined) {

--- a/src/pages/api/v1/services/[service_id]/index.js
+++ b/src/pages/api/v1/services/[service_id]/index.js
@@ -10,6 +10,7 @@ import authorization from "@/infra/authorization.js";
 const router = createRouter();
 
 router.delete(deleteHandler);
+router.patch(patchHandler);
 
 export default router.handler(controller.errorHandlers);
 
@@ -76,6 +77,87 @@ async function deleteHandler(request, response) {
   const updatedService = await db.service.update({
     where: { serviceId },
     data: { isActive: false },
+    select: serviceSelect,
+  });
+
+  return response.status(200).json(mapServiceResponse(updatedService));
+}
+
+async function patchHandler(request, response) {
+  const { user } =
+    await authentication.getAuthenticatedUserFromRequest(request);
+  authorization.ensureAdmin(user);
+
+  const serviceId = extractServiceId(request);
+
+  if (Object.keys(request.body).length === 0) {
+    throw new ValidationError({
+      message: "The request body is empty.",
+      action: "Provide the fields to update.",
+    });
+  }
+
+  const { service_name, service_description, duration, price } = request.body;
+
+  const dataToUpdate = {};
+
+  if (service_name !== undefined) {
+    if (typeof service_name !== "string" || service_name.trim() === "") {
+      throw new ValidationError({
+        message: "O nome do serviço não pode ser vazio.",
+        action: "Forneça um nome válido para o serviço.",
+      });
+    }
+    dataToUpdate.serviceName = service_name.trim();
+  }
+
+  if (service_description !== undefined) {
+    dataToUpdate.serviceDescription = service_description
+      ? service_description.trim()
+      : null;
+  }
+
+  if (duration !== undefined) {
+    if (
+      typeof duration !== "number" ||
+      duration <= 0 ||
+      !Number.isInteger(duration)
+    ) {
+      throw new ValidationError({
+        message:
+          "A duração do serviço deve ser um número inteiro positivo.",
+        action: "Forneça uma duração válida.",
+      });
+    }
+    dataToUpdate.duration = duration;
+  }
+
+  if (price !== undefined) {
+    if (isNaN(Number(price)) || Number(price) <= 0) {
+      throw new ValidationError({
+        message:
+          "O preço do serviço deve ser um número positivo.",
+        action: "Forneça um preço válido.",
+      });
+    }
+    dataToUpdate.price = Number(price);
+  }
+
+  const existingService = await db.service.findUnique({
+    where: { serviceId },
+    select: { isActive: true },
+  });
+
+  if (!existingService || !existingService.isActive) {
+    throw new NotFoundError({
+      message: "Service not found or is inactive.",
+      action: "Verify if the service_id is correct and the service is active.",
+    });
+  }
+
+  const updatedService = await db.service.update({
+    where: { serviceId },
+    data: dataToUpdate,
     select: serviceSelect,
   });
 

--- a/src/pages/api/v1/services/[service_id]/index.js
+++ b/src/pages/api/v1/services/[service_id]/index.js
@@ -124,8 +124,7 @@ async function patchHandler(request, response) {
       !Number.isInteger(duration)
     ) {
       throw new ValidationError({
-        message:
-          "A duração do serviço deve ser um número inteiro positivo.",
+        message: "A duração do serviço deve ser um número inteiro positivo.",
         action: "Forneça uma duração válida.",
       });
     }
@@ -135,8 +134,7 @@ async function patchHandler(request, response) {
   if (price !== undefined) {
     if (isNaN(Number(price)) || Number(price) <= 0) {
       throw new ValidationError({
-        message:
-          "O preço do serviço deve ser um número positivo.",
+        message: "O preço do serviço deve ser um número positivo.",
         action: "Forneça um preço válido.",
       });
     }

--- a/src/pages/dashboard/employees.jsx
+++ b/src/pages/dashboard/employees.jsx
@@ -182,36 +182,38 @@ const INITIAL_FORM = {
   confirm_password: "",
 };
 
-function validate(form) {
+function validate(form, isEditMode) {
   const errors = {};
 
   if (!form.barber_name.trim()) {
     errors.barber_name = "O nome do barbeiro é obrigatório.";
   }
 
-  if (!form.username.trim()) {
-    errors.username = "O nome de usuário é obrigatório.";
-  }
-
-  if (!form.email.trim()) {
-    errors.email = "O e-mail é obrigatório.";
-  }
-
-  if (!form.password) {
-    errors.password = "A senha é obrigatória.";
-  } else {
-    const hasLowercase = /[a-z]/.test(form.password);
-    const hasUppercase = /[A-Z]/.test(form.password);
-    const hasNumber = /[0-9]/.test(form.password);
-    const hasMinLength = form.password.length >= 8;
-
-    if (!hasLowercase || !hasUppercase || !hasNumber || !hasMinLength) {
-      errors.password = "A senha não atende aos requisitos.";
+  if (!isEditMode) {
+    if (!form.username.trim()) {
+      errors.username = "O nome de usuário é obrigatório.";
     }
-  }
 
-  if (form.password !== form.confirm_password) {
-    errors.confirm_password = "As senhas não coincidem.";
+    if (!form.email.trim()) {
+      errors.email = "O e-mail é obrigatório.";
+    }
+
+    if (!form.password) {
+      errors.password = "A senha é obrigatória.";
+    } else {
+      const hasLowercase = /[a-z]/.test(form.password);
+      const hasUppercase = /[A-Z]/.test(form.password);
+      const hasNumber = /[0-9]/.test(form.password);
+      const hasMinLength = form.password.length >= 8;
+
+      if (!hasLowercase || !hasUppercase || !hasNumber || !hasMinLength) {
+        errors.password = "A senha não atende aos requisitos.";
+      }
+    }
+
+    if (form.password !== form.confirm_password) {
+      errors.confirm_password = "As senhas não coincidem.";
+    }
   }
 
   // Paired time fields
@@ -232,15 +234,31 @@ function validate(form) {
   return errors;
 }
 
-function BarberForm({ onBarberCreated }) {
-  const [form, setForm] = useState(INITIAL_FORM);
+function BarberForm({ barberToEdit, onBarberCreated, onBarberUpdated, onCancelEdit }) {
+  const [form, setForm] = useState(() => {
+    if (barberToEdit) {
+      return {
+        barber_name: barberToEdit.barber_name,
+        phone_number: formatPhone(barberToEdit.phone_number || ""),
+        work_start: barberToEdit.work_start || "",
+        work_end: barberToEdit.work_end || "",
+        lunch_start: barberToEdit.lunch_start || "",
+        lunch_end: barberToEdit.lunch_end || "",
+        username: "",
+        email: "",
+        password: "",
+        confirm_password: "",
+      };
+    }
+    return INITIAL_FORM;
+  });
   const [touched, setTouched] = useState({});
   const [submitting, setSubmitting] = useState(false);
   const [apiError, setApiError] = useState(null);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
-  const errors = validate(form);
+  const errors = validate(form, !!barberToEdit);
 
   const passwordRules = useMemo(() => {
     const hasLowercase = /[a-z]/.test(form.password);
@@ -319,12 +337,20 @@ function BarberForm({ onBarberCreated }) {
     setApiError(null);
 
     try {
+      const isEditMode = !!barberToEdit;
+      const url = isEditMode
+        ? `/api/v1/barbers/${barberToEdit.barber_id}`
+        : "/api/v1/barbers";
+
       const body = {
         barber_name: form.barber_name.trim(),
-        username: form.username.trim(),
-        email: form.email.trim(),
-        password: form.password,
       };
+
+      if (!isEditMode) {
+        body.username = form.username.trim();
+        body.email = form.email.trim();
+        body.password = form.password;
+      }
 
       const phoneDigits = getPhoneDigits(form.phone_number);
       if (phoneDigits) body.phone_number = phoneDigits;
@@ -333,8 +359,8 @@ function BarberForm({ onBarberCreated }) {
       if (form.lunch_start) body.lunch_start = form.lunch_start;
       if (form.lunch_end) body.lunch_end = form.lunch_end;
 
-      const res = await fetch("/api/v1/barbers", {
-        method: "POST",
+      const res = await fetch(url, {
+        method: isEditMode ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
@@ -342,12 +368,16 @@ function BarberForm({ onBarberCreated }) {
       const data = await res.json();
 
       if (!res.ok) {
-        throw new Error(data.message || "Erro ao cadastrar barbeiro.");
+        throw new Error(data.message || `Erro ao ${isEditMode ? "atualizar" : "cadastrar"} barbeiro.`);
       }
 
-      onBarberCreated(data.barber);
-      setForm(INITIAL_FORM);
-      setTouched({});
+      if (isEditMode) {
+        onBarberUpdated(data);
+      } else {
+        onBarberCreated(data.barber);
+        setForm(INITIAL_FORM);
+        setTouched({});
+      }
     } catch (err) {
       setApiError(err.message);
     } finally {
@@ -521,159 +551,161 @@ function BarberForm({ onBarberCreated }) {
         </div>
 
         {/* ── Section 3: Acesso ao Sistema ── */}
-        <div>
-          <p className="text-[10px] font-label uppercase tracking-[0.2em] text-on-surface-variant/60 mb-4">
-            Acesso ao Sistema
-          </p>
+        {!barberToEdit && (
+          <div>
+            <p className="text-[10px] font-label uppercase tracking-[0.2em] text-on-surface-variant/60 mb-4">
+              Acesso ao Sistema
+            </p>
 
-          <div className="space-y-5">
-            {/* Username */}
-            <div>
-              <label htmlFor="username" className={labelClass()}>
-                Nome de Usuário <span aria-hidden="true">*</span>
-              </label>
-              <input
-                id="username"
-                name="username"
-                type="text"
-                value={form.username}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                placeholder="Ex: elias_barber"
-                autoComplete="username"
-                className={`${fieldBase} ${fieldBorderClass("username")}`}
-              />
-              {showError("username") && (
-                <p className="mt-1.5 text-xs text-red-400">{errors.username}</p>
-              )}
-            </div>
-
-            {/* Email */}
-            <div>
-              <label htmlFor="email" className={labelClass()}>
-                E-mail <span aria-hidden="true">*</span>
-              </label>
-              <input
-                id="email"
-                name="email"
-                type="email"
-                value={form.email}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                placeholder="elias@maximusbarbers.com"
-                autoComplete="email"
-                className={`${fieldBase} ${fieldBorderClass("email")}`}
-              />
-              {showError("email") && (
-                <p className="mt-1.5 text-xs text-red-400">{errors.email}</p>
-              )}
-            </div>
-
-            {/* Password */}
-            <div>
-              <label htmlFor="password" className={labelClass()}>
-                Senha <span aria-hidden="true">*</span>
-              </label>
-              <div className="relative">
+            <div className="space-y-5">
+              {/* Username */}
+              <div>
+                <label htmlFor="username" className={labelClass()}>
+                  Nome de Usuário <span aria-hidden="true">*</span>
+                </label>
                 <input
-                  id="password"
-                  name="password"
-                  type={showPassword ? "text" : "password"}
-                  value={form.password}
+                  id="username"
+                  name="username"
+                  type="text"
+                  value={form.username}
                   onChange={handleChange}
                   onBlur={handleBlur}
-                  placeholder="••••••••"
-                  autoComplete="new-password"
-                  className={`${fieldBase} pr-10 ${fieldBorderClass("password")}`}
+                  placeholder="Ex: elias_barber"
+                  autoComplete="username"
+                  className={`${fieldBase} ${fieldBorderClass("username")}`}
                 />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-on-surface-variant/50 hover:text-primary transition-colors focus:outline-none"
-                  aria-label={showPassword ? "Ocultar senha" : "Mostrar senha"}
-                  title={showPassword ? "Ocultar senha" : "Mostrar senha"}
-                >
-                  <span className="material-symbols-outlined text-[20px]">
-                    {showPassword ? "visibility_off" : "visibility"}
-                  </span>
-                </button>
+                {showError("username") && (
+                  <p className="mt-1.5 text-xs text-red-400">{errors.username}</p>
+                )}
               </div>
 
-              {/* Password Rules */}
-              {(touched.password || form.password.length > 0) && (
-                <div className="mt-4 bg-surface-container-lowest border border-outline-variant/20 p-4 text-[11px]">
-                  <h3 className="font-bold text-on-surface mb-2">
-                    A senha deve conter:
-                  </h3>
+              {/* Email */}
+              <div>
+                <label htmlFor="email" className={labelClass()}>
+                  E-mail <span aria-hidden="true">*</span>
+                </label>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  value={form.email}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  placeholder="elias@maximusbarbers.com"
+                  autoComplete="email"
+                  className={`${fieldBase} ${fieldBorderClass("email")}`}
+                />
+                {showError("email") && (
+                  <p className="mt-1.5 text-xs text-red-400">{errors.email}</p>
+                )}
+              </div>
 
-                  <p className={ruleClass(passwordRules.hasLowercase)}>
-                    Uma letra <b>minúscula</b>
-                  </p>
-
-                  <p className={ruleClass(passwordRules.hasUppercase)}>
-                    Uma letra <b>maiúscula</b>
-                  </p>
-
-                  <p className={ruleClass(passwordRules.hasNumber)}>
-                    Um <b>número</b>
-                  </p>
-
-                  <p className={ruleClass(passwordRules.hasMinLength)}>
-                    Mínimo de <b>8 caracteres</b>
-                  </p>
+              {/* Password */}
+              <div>
+                <label htmlFor="password" className={labelClass()}>
+                  Senha <span aria-hidden="true">*</span>
+                </label>
+                <div className="relative">
+                  <input
+                    id="password"
+                    name="password"
+                    type={showPassword ? "text" : "password"}
+                    value={form.password}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="••••••••"
+                    autoComplete="new-password"
+                    className={`${fieldBase} pr-10 ${fieldBorderClass("password")}`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-on-surface-variant/50 hover:text-primary transition-colors focus:outline-none"
+                    aria-label={showPassword ? "Ocultar senha" : "Mostrar senha"}
+                    title={showPassword ? "Ocultar senha" : "Mostrar senha"}
+                  >
+                    <span className="material-symbols-outlined text-[20px]">
+                      {showPassword ? "visibility_off" : "visibility"}
+                    </span>
+                  </button>
                 </div>
-              )}
-            </div>
 
-            {/* Confirmar Senha */}
-            <div>
-              <label htmlFor="confirm_password" className={labelClass()}>
-                Confirmar Senha <span aria-hidden="true">*</span>
-              </label>
+                {/* Password Rules */}
+                {(touched.password || form.password.length > 0) && (
+                  <div className="mt-4 bg-surface-container-lowest border border-outline-variant/20 p-4 text-[11px]">
+                    <h3 className="font-bold text-on-surface mb-2">
+                      A senha deve conter:
+                    </h3>
 
-              <div className="relative">
-                <input
-                  id="confirm_password"
-                  name="confirm_password"
-                  type={showConfirmPassword ? "text" : "password"}
-                  value={form.confirm_password}
-                  onChange={handleChange}
-                  onBlur={handleBlur}
-                  placeholder="••••••••"
-                  autoComplete="new-password"
-                  className={`${fieldBase} pr-10 ${fieldBorderClass("confirm_password")}`}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-on-surface-variant/50 hover:text-primary transition-colors focus:outline-none"
-                  aria-label={
-                    showConfirmPassword ? "Ocultar senha" : "Mostrar senha"
-                  }
-                  title={
-                    showConfirmPassword ? "Ocultar senha" : "Mostrar senha"
-                  }
-                >
-                  <span className="material-symbols-outlined text-[20px]">
-                    {showConfirmPassword ? "visibility_off" : "visibility"}
-                  </span>
-                </button>
+                    <p className={ruleClass(passwordRules.hasLowercase)}>
+                      Uma letra <b>minúscula</b>
+                    </p>
+
+                    <p className={ruleClass(passwordRules.hasUppercase)}>
+                      Uma letra <b>maiúscula</b>
+                    </p>
+
+                    <p className={ruleClass(passwordRules.hasNumber)}>
+                      Um <b>número</b>
+                    </p>
+
+                    <p className={ruleClass(passwordRules.hasMinLength)}>
+                      Mínimo de <b>8 caracteres</b>
+                    </p>
+                  </div>
+                )}
               </div>
 
-              {touched.confirm_password && form.confirm_password.length > 0 && (
-                <p
-                  className={`mt-2 text-[10px] uppercase tracking-widest font-bold ${
-                    passwordsMatch ? "text-green-400" : "text-red-400"
-                  }`}
-                >
-                  {passwordsMatch
-                    ? "Senhas coincidem"
-                    : "As senhas não coincidem"}
-                </p>
-              )}
+              {/* Confirmar Senha */}
+              <div>
+                <label htmlFor="confirm_password" className={labelClass()}>
+                  Confirmar Senha <span aria-hidden="true">*</span>
+                </label>
+
+                <div className="relative">
+                  <input
+                    id="confirm_password"
+                    name="confirm_password"
+                    type={showConfirmPassword ? "text" : "password"}
+                    value={form.confirm_password}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                    placeholder="••••••••"
+                    autoComplete="new-password"
+                    className={`${fieldBase} pr-10 ${fieldBorderClass("confirm_password")}`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-on-surface-variant/50 hover:text-primary transition-colors focus:outline-none"
+                    aria-label={
+                      showConfirmPassword ? "Ocultar senha" : "Mostrar senha"
+                    }
+                    title={
+                      showConfirmPassword ? "Ocultar senha" : "Mostrar senha"
+                    }
+                  >
+                    <span className="material-symbols-outlined text-[20px]">
+                      {showConfirmPassword ? "visibility_off" : "visibility"}
+                    </span>
+                  </button>
+                </div>
+
+                {touched.confirm_password && form.confirm_password.length > 0 && (
+                  <p
+                    className={`mt-2 text-[10px] uppercase tracking-widest font-bold ${
+                      passwordsMatch ? "text-green-400" : "text-red-400"
+                    }`}
+                  >
+                    {passwordsMatch
+                      ? "Senhas coincidem"
+                      : "As senhas não coincidem"}
+                  </p>
+                )}
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
         {/* API Error */}
         {apiError && (
@@ -686,22 +718,33 @@ function BarberForm({ onBarberCreated }) {
         )}
 
         {/* Submit */}
-        <div className="pt-2">
+        <div className="pt-2 flex flex-col lg:flex-row gap-4">
           <button
             type="submit"
             disabled={submitting}
             className="w-full lg:w-max px-12 py-4 bg-primary text-on-primary font-bold text-xs uppercase tracking-widest transition-all hover:translate-x-1 active:translate-x-0 relative group focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0"
           >
-            Cadastrar Profissional
+            {barberToEdit ? "Salvar Alterações" : "Cadastrar Profissional"}
             <span className="absolute inset-0 border border-primary translate-x-2 translate-y-2 -z-10 group-hover:translate-x-3 group-hover:translate-y-3 transition-transform opacity-30" />
           </button>
+          
+          {barberToEdit && (
+            <button
+              type="button"
+              disabled={submitting}
+              onClick={onCancelEdit}
+              className="w-full lg:w-max px-8 py-4 bg-transparent text-on-surface border border-outline-variant/30 font-bold text-xs uppercase tracking-widest transition-all hover:bg-surface-container-highest focus:outline-none focus:ring-2 focus:ring-outline-variant/50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancelar edição
+            </button>
+          )}
         </div>
       </form>
 
       <LoadingDialog
         isOpen={submitting}
-        title="Cadastrando profissional"
-        description="Estamos criando o perfil e o acesso ao sistema para o novo barbeiro."
+        title={barberToEdit ? "Atualizando barbeiro" : "Cadastrando profissional"}
+        description={barberToEdit ? "Estamos atualizando os dados operacionais deste profissional." : "Estamos criando o perfil e o acesso ao sistema para o novo barbeiro."}
       />
     </>
   );
@@ -751,13 +794,21 @@ export default function DashboardEmployeesPage() {
 
   function handleBarberEdit(barber) {
     setSelectedBarberToEdit(barber);
+  }
 
-    // TODO: Implement edit flow later.
-    // Example future behavior:
-    // - Open an edit modal
-    // - Fill the form with barber data
-    // - Submit PUT/PATCH request
-    // - Update the local barbers list
+  function handleBarberUpdated(updatedBarber) {
+    setBarbers((prev) =>
+      prev.map((barber) =>
+        barber.barber_id === updatedBarber.barber_id
+          ? updatedBarber
+          : barber
+      )
+    );
+    setSelectedBarberToEdit(null);
+  }
+
+  function handleCancelEdit() {
+    setSelectedBarberToEdit(null);
   }
 
   function handleBarberDeleteRequest(barberId) {
@@ -817,28 +868,23 @@ export default function DashboardEmployeesPage() {
         <div className="lg:col-span-5 bg-surface-container-low p-8 lg:p-12 flex flex-col">
           <div className="mb-8">
             <h3 className="text-2xl font-headline font-semibold text-on-surface mb-2">
-              Adicionar Novo Barbeiro
+              {selectedBarberToEdit ? "Editar Barbeiro" : "Adicionar Novo Barbeiro"}
             </h3>
 
             <p className="text-sm text-on-surface-variant font-light leading-relaxed">
-              Expanda o legado. Cadastre um novo profissional e crie seu acesso
-              ao sistema em uma única etapa.
+              {selectedBarberToEdit
+                ? "Edite os dados operacionais do profissional. As alterações serão salvas imediatamente."
+                : "Expanda o legado. Cadastre um novo profissional e crie seu acesso ao sistema em uma única etapa."}
             </p>
-
-            {selectedBarberToEdit && (
-              <div className="mt-6 bg-surface-container-lowest p-4">
-                <p className="text-[10px] font-label uppercase tracking-widest text-primary mb-1">
-                  Barbeiro selecionado para edição
-                </p>
-
-                <p className="text-sm text-on-surface-variant">
-                  {selectedBarberToEdit.barber_name}
-                </p>
-              </div>
-            )}
           </div>
 
-          <BarberForm onBarberCreated={handleBarberCreated} />
+          <BarberForm 
+            key={selectedBarberToEdit ? selectedBarberToEdit.barber_id : "create"}
+            barberToEdit={selectedBarberToEdit}
+            onBarberCreated={handleBarberCreated}
+            onBarberUpdated={handleBarberUpdated}
+            onCancelEdit={handleCancelEdit}
+          />
         </div>
 
         {/* Right Column: Barbers List */}

--- a/src/pages/dashboard/employees.jsx
+++ b/src/pages/dashboard/employees.jsx
@@ -234,7 +234,12 @@ function validate(form, isEditMode) {
   return errors;
 }
 
-function BarberForm({ barberToEdit, onBarberCreated, onBarberUpdated, onCancelEdit }) {
+function BarberForm({
+  barberToEdit,
+  onBarberCreated,
+  onBarberUpdated,
+  onCancelEdit,
+}) {
   const [form, setForm] = useState(() => {
     if (barberToEdit) {
       return {
@@ -368,7 +373,10 @@ function BarberForm({ barberToEdit, onBarberCreated, onBarberUpdated, onCancelEd
       const data = await res.json();
 
       if (!res.ok) {
-        throw new Error(data.message || `Erro ao ${isEditMode ? "atualizar" : "cadastrar"} barbeiro.`);
+        throw new Error(
+          data.message ||
+            `Erro ao ${isEditMode ? "atualizar" : "cadastrar"} barbeiro.`,
+        );
       }
 
       if (isEditMode) {
@@ -575,7 +583,9 @@ function BarberForm({ barberToEdit, onBarberCreated, onBarberUpdated, onCancelEd
                   className={`${fieldBase} ${fieldBorderClass("username")}`}
                 />
                 {showError("username") && (
-                  <p className="mt-1.5 text-xs text-red-400">{errors.username}</p>
+                  <p className="mt-1.5 text-xs text-red-400">
+                    {errors.username}
+                  </p>
                 )}
               </div>
 
@@ -621,7 +631,9 @@ function BarberForm({ barberToEdit, onBarberCreated, onBarberUpdated, onCancelEd
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
                     className="absolute right-2 top-1/2 -translate-y-1/2 text-on-surface-variant/50 hover:text-primary transition-colors focus:outline-none"
-                    aria-label={showPassword ? "Ocultar senha" : "Mostrar senha"}
+                    aria-label={
+                      showPassword ? "Ocultar senha" : "Mostrar senha"
+                    }
                     title={showPassword ? "Ocultar senha" : "Mostrar senha"}
                   >
                     <span className="material-symbols-outlined text-[20px]">
@@ -691,17 +703,18 @@ function BarberForm({ barberToEdit, onBarberCreated, onBarberUpdated, onCancelEd
                   </button>
                 </div>
 
-                {touched.confirm_password && form.confirm_password.length > 0 && (
-                  <p
-                    className={`mt-2 text-[10px] uppercase tracking-widest font-bold ${
-                      passwordsMatch ? "text-green-400" : "text-red-400"
-                    }`}
-                  >
-                    {passwordsMatch
-                      ? "Senhas coincidem"
-                      : "As senhas não coincidem"}
-                  </p>
-                )}
+                {touched.confirm_password &&
+                  form.confirm_password.length > 0 && (
+                    <p
+                      className={`mt-2 text-[10px] uppercase tracking-widest font-bold ${
+                        passwordsMatch ? "text-green-400" : "text-red-400"
+                      }`}
+                    >
+                      {passwordsMatch
+                        ? "Senhas coincidem"
+                        : "As senhas não coincidem"}
+                    </p>
+                  )}
               </div>
             </div>
           </div>
@@ -727,7 +740,7 @@ function BarberForm({ barberToEdit, onBarberCreated, onBarberUpdated, onCancelEd
             {barberToEdit ? "Salvar Alterações" : "Cadastrar Profissional"}
             <span className="absolute inset-0 border border-primary translate-x-2 translate-y-2 -z-10 group-hover:translate-x-3 group-hover:translate-y-3 transition-transform opacity-30" />
           </button>
-          
+
           {barberToEdit && (
             <button
               type="button"
@@ -743,8 +756,14 @@ function BarberForm({ barberToEdit, onBarberCreated, onBarberUpdated, onCancelEd
 
       <LoadingDialog
         isOpen={submitting}
-        title={barberToEdit ? "Atualizando barbeiro" : "Cadastrando profissional"}
-        description={barberToEdit ? "Estamos atualizando os dados operacionais deste profissional." : "Estamos criando o perfil e o acesso ao sistema para o novo barbeiro."}
+        title={
+          barberToEdit ? "Atualizando barbeiro" : "Cadastrando profissional"
+        }
+        description={
+          barberToEdit
+            ? "Estamos atualizando os dados operacionais deste profissional."
+            : "Estamos criando o perfil e o acesso ao sistema para o novo barbeiro."
+        }
       />
     </>
   );
@@ -799,10 +818,8 @@ export default function DashboardEmployeesPage() {
   function handleBarberUpdated(updatedBarber) {
     setBarbers((prev) =>
       prev.map((barber) =>
-        barber.barber_id === updatedBarber.barber_id
-          ? updatedBarber
-          : barber
-      )
+        barber.barber_id === updatedBarber.barber_id ? updatedBarber : barber,
+      ),
     );
     setSelectedBarberToEdit(null);
   }
@@ -868,7 +885,9 @@ export default function DashboardEmployeesPage() {
         <div className="lg:col-span-5 bg-surface-container-low p-8 lg:p-12 flex flex-col">
           <div className="mb-8">
             <h3 className="text-2xl font-headline font-semibold text-on-surface mb-2">
-              {selectedBarberToEdit ? "Editar Barbeiro" : "Adicionar Novo Barbeiro"}
+              {selectedBarberToEdit
+                ? "Editar Barbeiro"
+                : "Adicionar Novo Barbeiro"}
             </h3>
 
             <p className="text-sm text-on-surface-variant font-light leading-relaxed">
@@ -878,8 +897,10 @@ export default function DashboardEmployeesPage() {
             </p>
           </div>
 
-          <BarberForm 
-            key={selectedBarberToEdit ? selectedBarberToEdit.barber_id : "create"}
+          <BarberForm
+            key={
+              selectedBarberToEdit ? selectedBarberToEdit.barber_id : "create"
+            }
             barberToEdit={selectedBarberToEdit}
             onBarberCreated={handleBarberCreated}
             onBarberUpdated={handleBarberUpdated}

--- a/src/pages/dashboard/services.jsx
+++ b/src/pages/dashboard/services.jsx
@@ -169,7 +169,12 @@ function validate(formData) {
   return errors;
 }
 
-function ServiceForm({ serviceToEdit, onServiceCreated, onServiceUpdated, onCancelEdit }) {
+function ServiceForm({
+  serviceToEdit,
+  onServiceCreated,
+  onServiceUpdated,
+  onCancelEdit,
+}) {
   const [formData, setFormData] = useState(() => {
     if (serviceToEdit) {
       return {
@@ -212,10 +217,10 @@ function ServiceForm({ serviceToEdit, onServiceCreated, onServiceUpdated, onCanc
 
     try {
       const isEditMode = !!serviceToEdit;
-      const url = isEditMode 
+      const url = isEditMode
         ? `/api/v1/services/${serviceToEdit.service_id}`
         : "/api/v1/services";
-      
+
       const res = await fetch(url, {
         method: isEditMode ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
@@ -230,7 +235,10 @@ function ServiceForm({ serviceToEdit, onServiceCreated, onServiceUpdated, onCanc
       const data = await res.json();
 
       if (!res.ok) {
-        throw new Error(data.message || `Erro ao ${isEditMode ? 'atualizar' : 'cadastrar'} serviço.`);
+        throw new Error(
+          data.message ||
+            `Erro ao ${isEditMode ? "atualizar" : "cadastrar"} serviço.`,
+        );
       }
 
       if (isEditMode) {
@@ -385,7 +393,7 @@ function ServiceForm({ serviceToEdit, onServiceCreated, onServiceUpdated, onCanc
             {serviceToEdit ? "Salvar Alterações" : "Cadastrar Serviço"}
             <span className="absolute inset-0 border border-primary translate-x-2 translate-y-2 -z-10 group-hover:translate-x-3 group-hover:translate-y-3 transition-transform opacity-30" />
           </button>
-          
+
           {serviceToEdit && (
             <button
               type="button"
@@ -402,7 +410,11 @@ function ServiceForm({ serviceToEdit, onServiceCreated, onServiceUpdated, onCanc
       <LoadingDialog
         isOpen={submitting}
         title={serviceToEdit ? "Atualizando serviço" : "Cadastrando serviço"}
-        description={serviceToEdit ? "Estamos atualizando os dados do serviço. Isso levará apenas um momento." : "Estamos registrando o novo serviço no sistema. Isso levará apenas um momento."}
+        description={
+          serviceToEdit
+            ? "Estamos atualizando os dados do serviço. Isso levará apenas um momento."
+            : "Estamos registrando o novo serviço no sistema. Isso levará apenas um momento."
+        }
       />
     </>
   );
@@ -459,8 +471,8 @@ export default function DashboardServicesPage() {
       prev.map((service) =>
         service.service_id === updatedService.service_id
           ? updatedService
-          : service
-      )
+          : service,
+      ),
     );
     setSelectedServiceToEdit(null);
   }
@@ -537,10 +549,14 @@ export default function DashboardServicesPage() {
             </p>
           </div>
 
-          <ServiceForm 
-            key={selectedServiceToEdit ? selectedServiceToEdit.service_id : "create"}
+          <ServiceForm
+            key={
+              selectedServiceToEdit
+                ? selectedServiceToEdit.service_id
+                : "create"
+            }
             serviceToEdit={selectedServiceToEdit}
-            onServiceCreated={handleServiceCreated} 
+            onServiceCreated={handleServiceCreated}
             onServiceUpdated={handleServiceUpdated}
             onCancelEdit={handleCancelEdit}
           />

--- a/src/pages/dashboard/services.jsx
+++ b/src/pages/dashboard/services.jsx
@@ -169,8 +169,18 @@ function validate(formData) {
   return errors;
 }
 
-function ServiceForm({ onServiceCreated }) {
-  const [formData, setFormData] = useState(INITIAL_FORM);
+function ServiceForm({ serviceToEdit, onServiceCreated, onServiceUpdated, onCancelEdit }) {
+  const [formData, setFormData] = useState(() => {
+    if (serviceToEdit) {
+      return {
+        name: serviceToEdit.service_name,
+        description: serviceToEdit.service_description || "",
+        duration: String(serviceToEdit.duration),
+        price: String(serviceToEdit.price),
+      };
+    }
+    return INITIAL_FORM;
+  });
   const [touched, setTouched] = useState(INITIAL_TOUCHED);
   const [submitting, setSubmitting] = useState(false);
   const [apiError, setApiError] = useState(null);
@@ -201,8 +211,13 @@ function ServiceForm({ onServiceCreated }) {
     setApiError(null);
 
     try {
-      const res = await fetch("/api/v1/services", {
-        method: "POST",
+      const isEditMode = !!serviceToEdit;
+      const url = isEditMode 
+        ? `/api/v1/services/${serviceToEdit.service_id}`
+        : "/api/v1/services";
+      
+      const res = await fetch(url, {
+        method: isEditMode ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           service_name: formData.name.trim(),
@@ -215,12 +230,16 @@ function ServiceForm({ onServiceCreated }) {
       const data = await res.json();
 
       if (!res.ok) {
-        throw new Error(data.message || "Erro ao cadastrar serviço.");
+        throw new Error(data.message || `Erro ao ${isEditMode ? 'atualizar' : 'cadastrar'} serviço.`);
       }
 
-      onServiceCreated(data);
-      setFormData(INITIAL_FORM);
-      setTouched(INITIAL_TOUCHED);
+      if (isEditMode) {
+        onServiceUpdated(data);
+      } else {
+        onServiceCreated(data);
+        setFormData(INITIAL_FORM);
+        setTouched(INITIAL_TOUCHED);
+      }
     } catch (err) {
       setApiError(err.message);
     } finally {
@@ -357,22 +376,33 @@ function ServiceForm({ onServiceCreated }) {
         )}
 
         {/* Submit */}
-        <div className="pt-4">
+        <div className="pt-4 flex flex-col lg:flex-row gap-4">
           <button
             type="submit"
             disabled={submitting}
             className="w-full lg:w-max px-12 py-4 bg-primary text-on-primary font-bold text-xs uppercase tracking-widest transition-all hover:translate-x-1 active:translate-x-0 relative group focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:translate-x-0"
           >
-            Cadastrar Serviço
+            {serviceToEdit ? "Salvar Alterações" : "Cadastrar Serviço"}
             <span className="absolute inset-0 border border-primary translate-x-2 translate-y-2 -z-10 group-hover:translate-x-3 group-hover:translate-y-3 transition-transform opacity-30" />
           </button>
+          
+          {serviceToEdit && (
+            <button
+              type="button"
+              disabled={submitting}
+              onClick={onCancelEdit}
+              className="w-full lg:w-max px-8 py-4 bg-transparent text-on-surface border border-outline-variant/30 font-bold text-xs uppercase tracking-widest transition-all hover:bg-surface-container-highest focus:outline-none focus:ring-2 focus:ring-outline-variant/50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancelar edição
+            </button>
+          )}
         </div>
       </form>
 
       <LoadingDialog
         isOpen={submitting}
-        title="Cadastrando serviço"
-        description="Estamos registrando o novo serviço no sistema. Isso levará apenas um momento."
+        title={serviceToEdit ? "Atualizando serviço" : "Cadastrando serviço"}
+        description={serviceToEdit ? "Estamos atualizando os dados do serviço. Isso levará apenas um momento." : "Estamos registrando o novo serviço no sistema. Isso levará apenas um momento."}
       />
     </>
   );
@@ -422,13 +452,21 @@ export default function DashboardServicesPage() {
 
   function handleServiceEdit(service) {
     setSelectedServiceToEdit(service);
+  }
 
-    // TODO: Implement edit flow later.
-    // Example future behavior:
-    // - Open an edit modal
-    // - Fill the form with service data
-    // - Submit PUT/PATCH request
-    // - Update the local services list
+  function handleServiceUpdated(updatedService) {
+    setServices((prev) =>
+      prev.map((service) =>
+        service.service_id === updatedService.service_id
+          ? updatedService
+          : service
+      )
+    );
+    setSelectedServiceToEdit(null);
+  }
+
+  function handleCancelEdit() {
+    setSelectedServiceToEdit(null);
   }
 
   function handleServiceDeleteRequest(serviceId) {
@@ -489,28 +527,23 @@ export default function DashboardServicesPage() {
         <div className="lg:col-span-5 bg-surface-container-low p-8 lg:p-12 flex flex-col">
           <div className="mb-8">
             <h3 className="text-2xl font-headline font-semibold text-on-surface mb-2">
-              Adicionar Serviço
+              {selectedServiceToEdit ? "Editar Serviço" : "Adicionar Serviço"}
             </h3>
 
             <p className="text-sm text-on-surface-variant font-light leading-relaxed">
-              Cadastre um novo serviço disponível para agendamento. O serviço
-              será listado imediatamente após o cadastro.
+              {selectedServiceToEdit
+                ? "Edite os dados do serviço selecionado. As alterações serão salvas imediatamente."
+                : "Cadastre um novo serviço disponível para agendamento. O serviço será listado imediatamente após o cadastro."}
             </p>
-
-            {selectedServiceToEdit && (
-              <div className="mt-6 bg-surface-container-lowest p-4">
-                <p className="text-[10px] font-label uppercase tracking-widest text-primary mb-1">
-                  Serviço selecionado para edição
-                </p>
-
-                <p className="text-sm text-on-surface-variant">
-                  {selectedServiceToEdit.service_name}
-                </p>
-              </div>
-            )}
           </div>
 
-          <ServiceForm onServiceCreated={handleServiceCreated} />
+          <ServiceForm 
+            key={selectedServiceToEdit ? selectedServiceToEdit.service_id : "create"}
+            serviceToEdit={selectedServiceToEdit}
+            onServiceCreated={handleServiceCreated} 
+            onServiceUpdated={handleServiceUpdated}
+            onCancelEdit={handleCancelEdit}
+          />
         </div>
 
         {/* Right Column: Services List */}

--- a/src/tests/integration/api/v1/barbers/patch.test.js
+++ b/src/tests/integration/api/v1/barbers/patch.test.js
@@ -20,7 +20,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
           body: JSON.stringify({
             barber_name: "New Name",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(401);
@@ -51,7 +51,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
           body: JSON.stringify({
             barber_name: "New Name",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(403);
@@ -92,7 +92,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
           body: JSON.stringify({
             barber_name: "New Name",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -123,7 +123,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
           body: JSON.stringify({
             phone_number: "22888888888",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -152,7 +152,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
             work_start: "09:00",
             work_end: "17:00",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -183,7 +183,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
             lunch_start: "13:00",
             lunch_end: "14:00",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -217,7 +217,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
             work_start: "10:00",
             work_end: "20:00",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -250,7 +250,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
           body: JSON.stringify({
             barber_name: "Preserved Barber Updated",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -276,7 +276,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
             Cookie: `session_id=${adminSessionToken}`,
           },
           body: JSON.stringify({}),
-        }
+        },
       );
 
       expect(response.status).toBe(400);
@@ -301,7 +301,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
           body: JSON.stringify({
             barber_name: "Try Update",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(404);
@@ -330,7 +330,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
             access_level: "admin",
             is_active: false,
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -360,7 +360,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
           body: JSON.stringify({
             barber_name: "Shape Test Barber Updated",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -371,7 +371,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
           barber_id: barber.barberId,
           barber_name: "Shape Test Barber Updated",
           is_active: true,
-        })
+        }),
       );
       expect(responseBody.created_at).toBeDefined();
       expect(responseBody.updated_at).toBeDefined();
@@ -398,7 +398,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
           body: JSON.stringify({
             lunch_start: "12:00",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(400);
@@ -425,7 +425,7 @@ describe("PATCH /api/v1/barbers/[barber_id]", () => {
             lunch_start: "18:30",
             lunch_end: "19:30",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(400);

--- a/src/tests/integration/api/v1/barbers/patch.test.js
+++ b/src/tests/integration/api/v1/barbers/patch.test.js
@@ -1,0 +1,436 @@
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+
+describe("PATCH /api/v1/barbers/[barber_id]", () => {
+  describe("Anonymous user", () => {
+    test("Cannot patch barber (401)", async () => {
+      await orchestrator.clearDatabase();
+
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber to patch",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            barber_name: "New Name",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(401);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("UnauthorizedError");
+    });
+  });
+
+  describe("Authenticated Barber user", () => {
+    test("Cannot patch barber (403)", async () => {
+      const barberUser = await orchestrator.createUser({
+        accessLevel: "barber",
+      });
+      const session = await orchestrator.createSession(barberUser.userId);
+
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber forbidden",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${session.token}`,
+          },
+          body: JSON.stringify({
+            barber_name: "New Name",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(403);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ForbiddenError");
+    });
+  });
+
+  describe("Authenticated Admin user", () => {
+    let adminSessionToken;
+
+    beforeAll(async () => {
+      const adminUser = await orchestrator.createUser({
+        accessLevel: "admin",
+      });
+      const session = await orchestrator.createSession(adminUser.userId);
+      adminSessionToken = session.token;
+    });
+
+    test("Can update only barber_name", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Old Name",
+        phoneNumber: "11999999999",
+        workStart: "08:00",
+        workEnd: "18:00",
+        lunchStart: "12:00",
+        lunchEnd: "13:00",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            barber_name: "New Name",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.barber_name).toBe("New Name");
+      expect(responseBody.phone_number).toBe("11999999999");
+      expect(responseBody.work_start).toBe("08:00");
+      expect(responseBody.work_end).toBe("18:00");
+      expect(responseBody.lunch_start).toBe("12:00");
+      expect(responseBody.lunch_end).toBe("13:00");
+    });
+
+    test("Can update only phone_number", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "My Barber",
+        phoneNumber: "11999999999",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            phone_number: "22888888888",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.barber_name).toBe("My Barber");
+      expect(responseBody.phone_number).toBe("22888888888");
+    });
+
+    test("Can update only work_start/work_end", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "My Barber",
+        workStart: "08:00",
+        workEnd: "18:00",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            work_start: "09:00",
+            work_end: "17:00",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.work_start).toBe("09:00");
+      expect(responseBody.work_end).toBe("17:00");
+    });
+
+    test("Can update only lunch_start/lunch_end", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "My Barber",
+        workStart: "08:00",
+        workEnd: "18:00",
+        lunchStart: "12:00",
+        lunchEnd: "13:00",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            lunch_start: "13:00",
+            lunch_end: "14:00",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.lunch_start).toBe("13:00");
+      expect(responseBody.lunch_end).toBe("14:00");
+    });
+
+    test("Can update multiple profile fields", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Old Barber",
+        phoneNumber: "11999999999",
+        workStart: "08:00",
+        workEnd: "18:00",
+        lunchStart: "12:00",
+        lunchEnd: "13:00",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            barber_name: "New Barber",
+            phone_number: "22888888888",
+            work_start: "10:00",
+            work_end: "20:00",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.barber_name).toBe("New Barber");
+      expect(responseBody.phone_number).toBe("22888888888");
+      expect(responseBody.work_start).toBe("10:00");
+      expect(responseBody.work_end).toBe("20:00");
+      expect(responseBody.lunch_start).toBe("12:00");
+      expect(responseBody.lunch_end).toBe("13:00");
+    });
+
+    test("Omitted fields are preserved", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Preserved Barber",
+        phoneNumber: "11999999999",
+        workStart: "08:00",
+        workEnd: "18:00",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            barber_name: "Preserved Barber Updated",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.barber_name).toBe("Preserved Barber Updated");
+      expect(responseBody.phone_number).toBe("11999999999");
+      expect(responseBody.work_start).toBe("08:00");
+      expect(responseBody.work_end).toBe("18:00");
+    });
+
+    test("Empty body returns 400", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Empty Body Barber",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({}),
+        }
+      );
+
+      expect(response.status).toBe(400);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ValidationError");
+    });
+
+    test("Inactive/soft-deleted barber cannot be patched (404)", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Inactive Barber",
+        isActive: false,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            barber_name: "Try Update",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(404);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("NotFoundError");
+    });
+
+    test("User/account fields are ignored and not updated", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Barber with User",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            barber_name: "Barber Valid Name",
+            username: "newusername",
+            email: "newemail@example.com",
+            password: "newpassword",
+            access_level: "admin",
+            is_active: false,
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.barber_name).toBe("Barber Valid Name");
+      expect(responseBody.username).toBeUndefined();
+      expect(responseBody.email).toBeUndefined();
+      expect(responseBody.password).toBeUndefined();
+      expect(responseBody.access_level).toBeUndefined();
+      expect(responseBody.is_active).toBe(true); // Should not be affected by is_active: false
+    });
+
+    test("Response shape matches existing barber API conventions", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Shape Test Barber",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            barber_name: "Shape Test Barber Updated",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(
+        expect.objectContaining({
+          barber_id: barber.barberId,
+          barber_name: "Shape Test Barber Updated",
+          is_active: true,
+        })
+      );
+      expect(responseBody.created_at).toBeDefined();
+      expect(responseBody.updated_at).toBeDefined();
+      expect(responseBody.phone_number).toBeDefined(); // can be null
+      expect(responseBody.work_start).toBeDefined(); // can be null
+      expect(responseBody.work_end).toBeDefined(); // can be null
+      expect(responseBody.lunch_start).toBeDefined(); // can be null
+      expect(responseBody.lunch_end).toBeDefined(); // can be null
+    });
+
+    test("Fails if lunch_start is provided without lunch_end (400)", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Time Pair Test",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            lunch_start: "12:00",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(400);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ValidationError");
+    });
+
+    test("Fails if lunch interval is outside work interval (400)", async () => {
+      const barber = await orchestrator.createBarber({
+        barberName: "Interval Limits Test",
+        workStart: "09:00",
+        workEnd: "18:00",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/barbers/${barber.barberId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            lunch_start: "18:30",
+            lunch_end: "19:30",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(400);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ValidationError");
+    });
+  });
+});

--- a/src/tests/integration/api/v1/services/patch.test.js
+++ b/src/tests/integration/api/v1/services/patch.test.js
@@ -20,7 +20,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           body: JSON.stringify({
             service_name: "New Name",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(401);
@@ -51,7 +51,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           body: JSON.stringify({
             service_name: "New Name",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(403);
@@ -90,7 +90,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           body: JSON.stringify({
             service_name: "New Name",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -122,7 +122,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           body: JSON.stringify({
             service_description: "New description",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -149,7 +149,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           body: JSON.stringify({
             duration: 45,
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -175,7 +175,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           body: JSON.stringify({
             price: 75.5,
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -204,7 +204,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
             service_name: "New Name",
             duration: 60,
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -235,7 +235,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           body: JSON.stringify({
             service_name: "Preserved Name Updated",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -260,7 +260,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
             Cookie: `session_id=${adminSessionToken}`,
           },
           body: JSON.stringify({}),
-        }
+        },
       );
 
       expect(response.status).toBe(400);
@@ -285,7 +285,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           body: JSON.stringify({
             service_name: "Try Update",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(404);
@@ -309,7 +309,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           body: JSON.stringify({
             service_name: "Updated shape",
           }),
-        }
+        },
       );
 
       expect(response.status).toBe(200);
@@ -320,7 +320,7 @@ describe("PATCH /api/v1/services/[service_id]", () => {
           service_id: service.serviceId,
           service_name: "Updated shape",
           is_active: true,
-        })
+        }),
       );
       expect(responseBody.created_at).toBeDefined();
       expect(responseBody.updated_at).toBeDefined();

--- a/src/tests/integration/api/v1/services/patch.test.js
+++ b/src/tests/integration/api/v1/services/patch.test.js
@@ -1,0 +1,332 @@
+import orchestrator from "@/tests/orchestrator/orchestrator.mjs";
+import webserver from "@/infra/webserver.mjs";
+
+describe("PATCH /api/v1/services/[service_id]", () => {
+  describe("Anonymous user", () => {
+    test("Cannot patch service (401)", async () => {
+      await orchestrator.clearDatabase();
+
+      const service = await orchestrator.createService({
+        serviceName: "Service to patch",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            service_name: "New Name",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(401);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("UnauthorizedError");
+    });
+  });
+
+  describe("Authenticated Barber user", () => {
+    test("Cannot patch service (403)", async () => {
+      const barberUser = await orchestrator.createUser({
+        accessLevel: "barber",
+      });
+      const session = await orchestrator.createSession(barberUser.userId);
+
+      const service = await orchestrator.createService({
+        serviceName: "Service barber cannot patch",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${session.token}`,
+          },
+          body: JSON.stringify({
+            service_name: "New Name",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(403);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ForbiddenError");
+    });
+  });
+
+  describe("Authenticated Admin user", () => {
+    let adminSessionToken;
+
+    beforeAll(async () => {
+      const adminUser = await orchestrator.createUser({
+        accessLevel: "admin",
+      });
+      const session = await orchestrator.createSession(adminUser.userId);
+      adminSessionToken = session.token;
+    });
+
+    test("Can update only service_name", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Old Name",
+        serviceDescription: "Old description",
+        duration: 30,
+        price: 50,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            service_name: "New Name",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.service_name).toBe("New Name");
+      expect(responseBody.service_description).toBe("Old description");
+      expect(responseBody.duration).toBe(30);
+      expect(responseBody.price).toBe("50.00");
+      expect(responseBody.updated_at).not.toBe(service.updatedAt.toISOString());
+    });
+
+    test("Can update only service_description", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "My Service",
+        serviceDescription: "Old description",
+        duration: 30,
+        price: 50,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            service_description: "New description",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.service_name).toBe("My Service");
+      expect(responseBody.service_description).toBe("New description");
+    });
+
+    test("Can update only duration", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "My Service",
+        duration: 30,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            duration: 45,
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.duration).toBe(45);
+    });
+
+    test("Can update only price", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "My Service",
+        price: 50,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            price: 75.5,
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.price).toBe("75.50");
+    });
+
+    test("Can update multiple fields", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Old Name",
+        serviceDescription: "Old description",
+        duration: 30,
+        price: 50,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            service_name: "New Name",
+            duration: 60,
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.service_name).toBe("New Name");
+      expect(responseBody.service_description).toBe("Old description");
+      expect(responseBody.duration).toBe(60);
+      expect(responseBody.price).toBe("50.00");
+    });
+
+    test("Omitted fields are preserved", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Preserved Name",
+        serviceDescription: "Preserved Desc",
+        duration: 45,
+        price: 60,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            service_name: "Preserved Name Updated",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody.service_description).toBe("Preserved Desc");
+      expect(responseBody.duration).toBe(45);
+      expect(responseBody.price).toBe("60.00");
+    });
+
+    test("Empty body returns 400", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Service",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({}),
+        }
+      );
+
+      expect(response.status).toBe(400);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("ValidationError");
+    });
+
+    test("Inactive/soft-deleted service cannot be patched (404)", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Inactive Service",
+        isActive: false,
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            service_name: "Try Update",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(404);
+      const responseBody = await response.json();
+      expect(responseBody.name).toEqual("NotFoundError");
+    });
+
+    test("Response shape matches existing service API conventions", async () => {
+      const service = await orchestrator.createService({
+        serviceName: "Test shape",
+      });
+
+      const response = await fetch(
+        `${webserver.origin}/api/v1/services/${service.serviceId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `session_id=${adminSessionToken}`,
+          },
+          body: JSON.stringify({
+            service_name: "Updated shape",
+          }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(
+        expect.objectContaining({
+          service_id: service.serviceId,
+          service_name: "Updated shape",
+          is_active: true,
+        })
+      );
+      expect(responseBody.created_at).toBeDefined();
+      expect(responseBody.updated_at).toBeDefined();
+      expect(responseBody.service_description).toBeDefined(); // can be null
+      expect(responseBody.duration).toBeDefined();
+      expect(responseBody.price).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds PATCH/update support for services and barbers, including API endpoints, dashboard edit flows, and integration test coverage.

Admins can now edit existing services and barber operational data directly from the dashboard.

## Main changes

- Added service update flow
  - Adds admin-only `PATCH /api/v1/services/[service_id]`
  - Supports updating service name, description, duration, and price
  - Validates empty request bodies and invalid field values
  - Adds integration tests for service update behavior

- Added services dashboard edit mode
  - Reuses the service form for both creation and editing
  - Loads the selected service into the form
  - Updates the local services list after a successful save
  - Allows cancelling the edit state

- Added barber update flow
  - Adds admin-only `PATCH /api/v1/barbers/[barber_id]`
  - Supports updating barber name, phone number, work hours, lunch hours, and active status
  - Validates empty request bodies, time formats, work schedules, and lunch constraints
  - Adds integration tests for barber update behavior

- Added employees dashboard edit mode
  - Reuses the barber form for both creation and editing
  - Loads the selected barber into the form
  - Updates the local barber list after a successful save
  - Allows cancelling the edit state

## Notes

This PR completes the edit side of the dashboard management flow for services and barbers.

The update endpoints are restricted to admin users, matching the existing creation and soft-delete behavior.